### PR TITLE
Update ContainerBindingService

### DIFF
--- a/packages/iocuak/src/container/services/api/ContainerApiServiceImplementation.spec.ts
+++ b/packages/iocuak/src/container/services/api/ContainerApiServiceImplementation.spec.ts
@@ -103,7 +103,6 @@ describe(ContainerApiServiceImplementation.name, () => {
       it('should call containerService.binding.set()', () => {
         expect(containerServiceMock.binding.set).toHaveBeenCalledTimes(1);
         expect(containerServiceMock.binding.set).toHaveBeenCalledWith(
-          bindingFixture.id,
           bindingFixture,
         );
       });
@@ -140,7 +139,6 @@ describe(ContainerApiServiceImplementation.name, () => {
 
         expect(containerServiceMock.binding.set).toHaveBeenCalledTimes(1);
         expect(containerServiceMock.binding.set).toHaveBeenCalledWith(
-          serviceIdFixture,
           expectedValueBinding,
         );
       });

--- a/packages/iocuak/src/container/services/api/ContainerApiServiceImplementation.ts
+++ b/packages/iocuak/src/container/services/api/ContainerApiServiceImplementation.ts
@@ -25,7 +25,7 @@ export class ContainerApiServiceImplementation implements ContainerApiService {
         `No bindings found for type ${type.name}. An @injectable() decorator may be missing`,
       );
     } else {
-      this._containerService.binding.set(bindingFromType.id, bindingFromType);
+      this._containerService.binding.set(bindingFromType);
     }
   }
 
@@ -36,7 +36,7 @@ export class ContainerApiServiceImplementation implements ContainerApiService {
       value: value,
     };
 
-    this._containerService.binding.set(valueBinding.id, valueBinding);
+    this._containerService.binding.set(valueBinding);
   }
 
   public get<TInstance>(serviceId: ServiceId): TInstance {

--- a/packages/iocuak/src/container/services/domain/ContainerBindingService.ts
+++ b/packages/iocuak/src/container/services/domain/ContainerBindingService.ts
@@ -6,6 +6,8 @@ export interface ContainerBindingService {
     serviceId: ServiceId,
   ): Binding<TInstance, TArgs> | undefined;
 
+  getAll(): Map<ServiceId, Binding>;
+
   remove(serviceId: ServiceId): void;
 
   set<TInstance, TArgs extends unknown[]>(

--- a/packages/iocuak/src/container/services/domain/ContainerBindingService.ts
+++ b/packages/iocuak/src/container/services/domain/ContainerBindingService.ts
@@ -11,7 +11,6 @@ export interface ContainerBindingService {
   remove(serviceId: ServiceId): void;
 
   set<TInstance, TArgs extends unknown[]>(
-    serviceId: ServiceId,
     binding: Binding<TInstance, TArgs>,
   ): void;
 }

--- a/packages/iocuak/src/container/services/domain/ContainerBindingServiceImplementation.spec.ts
+++ b/packages/iocuak/src/container/services/domain/ContainerBindingServiceImplementation.spec.ts
@@ -92,21 +92,16 @@ describe(ContainerBindingServiceImplementation.name, () => {
         containerBindingServiceImplementation =
           new ContainerBindingServiceImplementation();
 
-        const serviceIdFixture: ServiceId = 'service-id';
-
         bindingFixture = {
           bindingType: BindingType.type,
-          id: serviceIdFixture,
+          id: 'service-id',
           scope: TaskScope.transient,
           type: class {},
         };
 
-        containerBindingServiceImplementation.set(
-          serviceIdFixture,
-          bindingFixture,
-        );
+        containerBindingServiceImplementation.set(bindingFixture);
 
-        result = containerBindingServiceImplementation.get(serviceIdFixture);
+        result = containerBindingServiceImplementation.get(bindingFixture.id);
       });
 
       it('should return the entry value', () => {
@@ -133,10 +128,7 @@ describe(ContainerBindingServiceImplementation.name, () => {
           type: class {},
         };
 
-        containerBindingServiceImplementation.set(
-          bindingFixture.id,
-          bindingFixture,
-        );
+        containerBindingServiceImplementation.set(bindingFixture);
 
         result = containerBindingServiceImplementation.getAll();
       });
@@ -186,10 +178,7 @@ describe(ContainerBindingServiceImplementation.name, () => {
           type: class {},
         };
 
-        containerBindingServiceImplementation.set(
-          bindingFixture.id,
-          bindingFixture,
-        );
+        containerBindingServiceImplementation.set(bindingFixture);
 
         result = containerBindingServiceImplementation.getAll();
       });
@@ -242,10 +231,7 @@ describe(ContainerBindingServiceImplementation.name, () => {
           type: class {},
         };
 
-        containerBindingServiceImplementation.set(
-          bindingFixture.id,
-          bindingFixture,
-        );
+        containerBindingServiceImplementation.set(bindingFixture);
 
         result = containerBindingServiceImplementation.getAll();
       });
@@ -260,7 +246,6 @@ describe(ContainerBindingServiceImplementation.name, () => {
 
   describe('.set()', () => {
     describe('when called', () => {
-      let serviceIdFixture: ServiceId;
       let bindingFixture: Binding;
       let containerBindingServiceImplementation: ContainerBindingServiceImplementation;
 
@@ -268,25 +253,21 @@ describe(ContainerBindingServiceImplementation.name, () => {
         containerBindingServiceImplementation =
           new ContainerBindingServiceImplementation();
 
-        serviceIdFixture = 'sample-service-id';
         bindingFixture = {
           bindingType: BindingType.type,
-          id: serviceIdFixture,
+          id: 'sample-service-id',
           scope: TaskScope.transient,
           type: class {},
         };
 
-        containerBindingServiceImplementation.set(
-          serviceIdFixture,
-          bindingFixture,
-        );
+        containerBindingServiceImplementation.set(bindingFixture);
       });
 
       describe('when .get() is called with the same service id', () => {
         let result: unknown;
 
         beforeAll(() => {
-          result = containerBindingServiceImplementation.get(serviceIdFixture);
+          result = containerBindingServiceImplementation.get(bindingFixture.id);
         });
 
         it('should return an instance', () => {
@@ -325,35 +306,29 @@ describe(ContainerBindingServiceImplementation.name, () => {
 
     describe('when called, and serviceIdToInstanceMap has an entry with the same service id', () => {
       let containerBindingServiceImplementation: ContainerBindingServiceImplementation;
-      let serviceIdFixture: ServiceId;
       let bindingFixture: Binding;
 
       beforeAll(() => {
         containerBindingServiceImplementation =
           new ContainerBindingServiceImplementation();
 
-        serviceIdFixture = 'sample-service-id';
-
         bindingFixture = {
           bindingType: BindingType.type,
-          id: serviceIdFixture,
+          id: 'sample-service-id',
           scope: TaskScope.transient,
           type: class {},
         };
 
-        containerBindingServiceImplementation.set(
-          serviceIdFixture,
-          bindingFixture,
-        );
+        containerBindingServiceImplementation.set(bindingFixture);
 
-        containerBindingServiceImplementation.remove(serviceIdFixture);
+        containerBindingServiceImplementation.remove(bindingFixture.id);
       });
 
       describe('when .get() is called with the same service id', () => {
         let result: unknown;
 
         beforeAll(() => {
-          result = containerBindingServiceImplementation.get(serviceIdFixture);
+          result = containerBindingServiceImplementation.get(bindingFixture.id);
         });
 
         it('should return undefined', () => {

--- a/packages/iocuak/src/container/services/domain/ContainerBindingServiceImplementation.spec.ts
+++ b/packages/iocuak/src/container/services/domain/ContainerBindingServiceImplementation.spec.ts
@@ -115,6 +115,149 @@ describe(ContainerBindingServiceImplementation.name, () => {
     });
   });
 
+  describe('.getAll()', () => {
+    describe('when called, and serviceIdToInstanceMap has an entry and parent is undefined', () => {
+      let containerBindingServiceImplementation: ContainerBindingServiceImplementation;
+      let bindingFixture: Binding;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        containerBindingServiceImplementation =
+          new ContainerBindingServiceImplementation();
+
+        bindingFixture = {
+          bindingType: BindingType.type,
+          id: 'service-id',
+          scope: TaskScope.transient,
+          type: class {},
+        };
+
+        containerBindingServiceImplementation.set(
+          bindingFixture.id,
+          bindingFixture,
+        );
+
+        result = containerBindingServiceImplementation.getAll();
+      });
+
+      it('should return a service to binding map', () => {
+        expect(result).toStrictEqual(
+          new Map<ServiceId, Binding>([[bindingFixture.id, bindingFixture]]),
+        );
+      });
+    });
+
+    describe('when called, and serviceIdToInstanceMap has an entry and parent has an entry with different id', () => {
+      let parentMock: jest.Mocked<ContainerBindingService>;
+      let containerBindingServiceImplementation: ContainerBindingServiceImplementation;
+      let parentBindingFixture: Binding;
+      let bindingFixture: Binding;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        parentBindingFixture = {
+          bindingType: BindingType.type,
+          id: 'parent-service-id',
+          scope: TaskScope.transient,
+          type: class {},
+        };
+
+        parentMock = {
+          getAll: jest
+            .fn()
+            .mockReturnValueOnce(
+              new Map<ServiceId, Binding>([
+                [parentBindingFixture.id, parentBindingFixture],
+              ]),
+            ),
+        } as Partial<
+          jest.Mocked<ContainerBindingService>
+        > as jest.Mocked<ContainerBindingService>;
+
+        containerBindingServiceImplementation =
+          new ContainerBindingServiceImplementation(parentMock);
+
+        bindingFixture = {
+          bindingType: BindingType.type,
+          id: 'service-id',
+          scope: TaskScope.transient,
+          type: class {},
+        };
+
+        containerBindingServiceImplementation.set(
+          bindingFixture.id,
+          bindingFixture,
+        );
+
+        result = containerBindingServiceImplementation.getAll();
+      });
+
+      it('should return a service to binding map', () => {
+        expect(result).toStrictEqual(
+          new Map<ServiceId, Binding>([
+            [bindingFixture.id, bindingFixture],
+            [parentBindingFixture.id, parentBindingFixture],
+          ]),
+        );
+      });
+    });
+
+    describe('when called, and serviceIdToInstanceMap has an entry and parent has an entry with same id', () => {
+      let parentMock: jest.Mocked<ContainerBindingService>;
+      let containerBindingServiceImplementation: ContainerBindingServiceImplementation;
+      let parentBindingFixture: Binding;
+      let bindingFixture: Binding;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        parentBindingFixture = {
+          bindingType: BindingType.type,
+          id: 'service-id',
+          scope: TaskScope.singleton,
+          type: class {},
+        };
+
+        parentMock = {
+          getAll: jest
+            .fn()
+            .mockReturnValueOnce(
+              new Map<ServiceId, Binding>([
+                [parentBindingFixture.id, parentBindingFixture],
+              ]),
+            ),
+        } as Partial<
+          jest.Mocked<ContainerBindingService>
+        > as jest.Mocked<ContainerBindingService>;
+
+        containerBindingServiceImplementation =
+          new ContainerBindingServiceImplementation(parentMock);
+
+        bindingFixture = {
+          bindingType: BindingType.type,
+          id: 'service-id',
+          scope: TaskScope.transient,
+          type: class {},
+        };
+
+        containerBindingServiceImplementation.set(
+          bindingFixture.id,
+          bindingFixture,
+        );
+
+        result = containerBindingServiceImplementation.getAll();
+      });
+
+      it('should return a service to binding map', () => {
+        expect(result).toStrictEqual(
+          new Map<ServiceId, Binding>([[bindingFixture.id, bindingFixture]]),
+        );
+      });
+    });
+  });
+
   describe('.set()', () => {
     describe('when called', () => {
       let serviceIdFixture: ServiceId;

--- a/packages/iocuak/src/container/services/domain/ContainerBindingServiceImplementation.ts
+++ b/packages/iocuak/src/container/services/domain/ContainerBindingServiceImplementation.ts
@@ -45,9 +45,8 @@ export class ContainerBindingServiceImplementation
   }
 
   public set<TInstance, TArgs extends unknown[]>(
-    serviceId: ServiceId,
     binding: Binding<TInstance, TArgs>,
   ): void {
-    this.#serviceIdToBindingMap.set(serviceId, binding as Binding);
+    this.#serviceIdToBindingMap.set(binding.id, binding as Binding);
   }
 }

--- a/packages/iocuak/src/container/services/domain/ContainerBindingServiceImplementation.ts
+++ b/packages/iocuak/src/container/services/domain/ContainerBindingServiceImplementation.ts
@@ -27,6 +27,19 @@ export class ContainerBindingServiceImplementation
     return binding;
   }
 
+  public getAll(): Map<ServiceId, Binding> {
+    const serviceIdToBindingMap: Map<ServiceId, Binding> =
+      this.#parent === undefined
+        ? new Map<ServiceId, Binding>()
+        : this.#parent.getAll();
+
+    for (const [serviceId, binding] of this.#serviceIdToBindingMap) {
+      serviceIdToBindingMap.set(serviceId, binding);
+    }
+
+    return serviceIdToBindingMap;
+  }
+
   public remove(serviceId: ServiceId): void {
     this.#serviceIdToBindingMap.delete(serviceId);
   }


### PR DESCRIPTION
### Changed
- Updated `ContainerBindingService` with `getAll`.
- Updated `ContainerBindingService.set` to no longer receive serviceId.