### PR TITLE
Add get class metadata api

### DIFF
--- a/packages/iocuak/src/binding/utils/api/convertBindingToBindingApi.ts
+++ b/packages/iocuak/src/binding/utils/api/convertBindingToBindingApi.ts
@@ -1,9 +1,22 @@
 import { taskScopeToTaskScopeApiMap } from '../../../task/models/api/taskScopeToTaskScopeApiMap';
 import { BindingApi } from '../../models/api/BindingApi';
 import { BindingApiType } from '../../models/api/BindingApiType';
+import { TypeBindingApi } from '../../models/api/TypeBindingApi';
+import { ValueBindingApi } from '../../models/api/ValueBindingApi';
 import { Binding } from '../../models/domain/Binding';
 import { BindingType } from '../../models/domain/BindingType';
+import { TypeBinding } from '../../models/domain/TypeBinding';
+import { ValueBinding } from '../../models/domain/ValueBinding';
 
+export function convertBindingToBindingApi<TInstance, TArgs extends unknown[]>(
+  binding: TypeBinding<TInstance, TArgs>,
+): TypeBindingApi<TInstance, TArgs>;
+export function convertBindingToBindingApi<TInstance>(
+  binding: ValueBinding<TInstance>,
+): ValueBindingApi<TInstance>;
+export function convertBindingToBindingApi<TInstance, TArgs extends unknown[]>(
+  binding: Binding<TInstance, TArgs>,
+): BindingApi<TInstance, TArgs>;
 export function convertBindingToBindingApi<TInstance, TArgs extends unknown[]>(
   binding: Binding<TInstance, TArgs>,
 ): BindingApi<TInstance, TArgs> {

--- a/packages/iocuak/src/container/services/api/MetadataApiService.ts
+++ b/packages/iocuak/src/container/services/api/MetadataApiService.ts
@@ -1,0 +1,13 @@
+import { TypeBindingApi } from '../../../binding/models/api/TypeBindingApi';
+import { Newable } from '../../../common/models/domain/Newable';
+import { ClassMetadataApi } from '../../../metadata/models/api/ClassMetadataApi';
+
+export interface MetadataApiService {
+  getBindingMetadata<TInstance, TArgs extends unknown[]>(
+    type: Newable<TInstance, TArgs>,
+  ): TypeBindingApi<TInstance, TArgs> | undefined;
+
+  getClassMetadata<TInstance, TArgs extends unknown[]>(
+    type: Newable<TInstance, TArgs>,
+  ): ClassMetadataApi;
+}

--- a/packages/iocuak/src/container/services/api/MetadataApiServiceImplementation.spec.ts
+++ b/packages/iocuak/src/container/services/api/MetadataApiServiceImplementation.spec.ts
@@ -1,0 +1,180 @@
+jest.mock('../../../binding/utils/api/convertBindingToBindingApi');
+jest.mock('../../../metadata/utils/api/convertClassMetadataToClassMetadataApi');
+
+import { BindingApi } from '../../../binding/models/api/BindingApi';
+import { BindingApiType } from '../../../binding/models/api/BindingApiType';
+import { Binding } from '../../../binding/models/domain/Binding';
+import { BindingType } from '../../../binding/models/domain/BindingType';
+import { convertBindingToBindingApi } from '../../../binding/utils/api/convertBindingToBindingApi';
+import { Newable } from '../../../common/models/domain/Newable';
+import { ClassMetadataApi } from '../../../metadata/models/api/ClassMetadataApi';
+import { ClassMetadata } from '../../../metadata/models/domain/ClassMetadata';
+import { convertClassMetadataToClassMetadataApi } from '../../../metadata/utils/api/convertClassMetadataToClassMetadataApi';
+import { TaskScopeApi } from '../../../task/models/api/TaskScopeApi';
+import { TaskScope } from '../../../task/models/domain/TaskScope';
+import { ContainerMetadataService } from '../domain/ContainerMetadataService';
+import { MetadataApiServiceImplementation } from './MetadataApiServiceImplementation';
+
+describe(MetadataApiServiceImplementation.name, () => {
+  let metadataServiceMock: jest.Mocked<ContainerMetadataService>;
+  let metadataApiServiceImplementation: MetadataApiServiceImplementation;
+
+  beforeAll(() => {
+    metadataServiceMock = {
+      getBindingMetadata: jest.fn(),
+      getClassMetadata: jest.fn(),
+    };
+
+    metadataApiServiceImplementation = new MetadataApiServiceImplementation(
+      metadataServiceMock,
+    );
+  });
+
+  describe('.getBindingMetadata', () => {
+    let typeFixture: Newable;
+
+    beforeAll(() => {
+      typeFixture = class {};
+    });
+
+    describe('when called, and metadataServiceMock.getBindingMetadata() returns undefined', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        metadataServiceMock.getBindingMetadata.mockReturnValueOnce(undefined);
+
+        result =
+          metadataApiServiceImplementation.getBindingMetadata(typeFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call metadataApiService.getBindingMetadata()', () => {
+        expect(metadataServiceMock.getBindingMetadata).toHaveBeenCalledTimes(1);
+        expect(metadataServiceMock.getBindingMetadata).toHaveBeenCalledWith(
+          typeFixture,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+
+    describe('when called, and metadataService.getBindingMetadata() returns Binding', () => {
+      let bindingFixture: Binding;
+      let bindingApiFixture: BindingApi;
+      let result: unknown;
+
+      beforeAll(() => {
+        bindingFixture = {
+          bindingType: BindingType.type,
+          id: 'service-id',
+          scope: TaskScope.singleton,
+          type: class {},
+        };
+
+        bindingApiFixture = {
+          bindingType: BindingApiType.type,
+          id: bindingFixture.id,
+          scope: TaskScopeApi.singleton,
+          type: bindingFixture.type,
+        };
+
+        metadataServiceMock.getBindingMetadata.mockReturnValueOnce(
+          bindingFixture,
+        );
+
+        (
+          convertBindingToBindingApi as jest.Mock<BindingApi, [Binding]>
+        ).mockReturnValueOnce(bindingApiFixture);
+
+        result =
+          metadataApiServiceImplementation.getBindingMetadata(typeFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call metadataApiService.getBindingMetadata()', () => {
+        expect(metadataServiceMock.getBindingMetadata).toHaveBeenCalledTimes(1);
+        expect(metadataServiceMock.getBindingMetadata).toHaveBeenCalledWith(
+          typeFixture,
+        );
+      });
+
+      it('should call convertBindingToBindingApi()', () => {
+        expect(convertBindingToBindingApi).toHaveBeenCalledTimes(1);
+        expect(convertBindingToBindingApi).toHaveBeenCalledWith(bindingFixture);
+      });
+
+      it('should return a bindingApi', () => {
+        expect(result).toStrictEqual(bindingApiFixture);
+      });
+    });
+  });
+
+  describe('.getClassMetadata', () => {
+    let typeFixture: Newable;
+
+    beforeAll(() => {
+      typeFixture = class {};
+    });
+
+    describe('when called', () => {
+      let classMetadataFixture: ClassMetadata;
+      let classMetadataApiFixture: ClassMetadataApi;
+      let result: unknown;
+
+      beforeAll(() => {
+        classMetadataFixture = {
+          constructorArguments: [],
+          properties: new Map(),
+        };
+
+        classMetadataApiFixture = {
+          constructorArguments: [],
+          properties: new Map(),
+        };
+
+        metadataServiceMock.getClassMetadata.mockReturnValueOnce(
+          classMetadataFixture,
+        );
+
+        (
+          convertClassMetadataToClassMetadataApi as jest.Mock<
+            ClassMetadataApi,
+            [ClassMetadata]
+          >
+        ).mockReturnValueOnce(classMetadataApiFixture);
+
+        result = metadataApiServiceImplementation.getClassMetadata(typeFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call metadataService.getClassMetadata()', () => {
+        expect(metadataServiceMock.getClassMetadata).toHaveBeenCalledTimes(1);
+        expect(metadataServiceMock.getClassMetadata).toHaveBeenCalledWith(
+          typeFixture,
+        );
+      });
+
+      it('should call convertClassMetadataToClassMetadataApi()', () => {
+        expect(convertClassMetadataToClassMetadataApi).toHaveBeenCalledTimes(1);
+        expect(convertClassMetadataToClassMetadataApi).toHaveBeenCalledWith(
+          classMetadataFixture,
+        );
+      });
+
+      it('should return ClassMetadataApi', () => {
+        expect(result).toStrictEqual(classMetadataApiFixture);
+      });
+    });
+  });
+});

--- a/packages/iocuak/src/container/services/api/MetadataApiServiceImplementation.ts
+++ b/packages/iocuak/src/container/services/api/MetadataApiServiceImplementation.ts
@@ -1,0 +1,37 @@
+import { TypeBindingApi } from '../../../binding/models/api/TypeBindingApi';
+import { TypeBinding } from '../../../binding/models/domain/TypeBinding';
+import { convertBindingToBindingApi } from '../../../binding/utils/api/convertBindingToBindingApi';
+import { Newable } from '../../../common/models/domain/Newable';
+import { ClassMetadataApi } from '../../../metadata/models/api/ClassMetadataApi';
+import { ClassMetadata } from '../../../metadata/models/domain/ClassMetadata';
+import { convertClassMetadataToClassMetadataApi } from '../../../metadata/utils/api/convertClassMetadataToClassMetadataApi';
+import { ContainerMetadataService } from '../domain/ContainerMetadataService';
+import { MetadataApiService } from './MetadataApiService';
+
+export class MetadataApiServiceImplementation implements MetadataApiService {
+  readonly #containerMetadataService: ContainerMetadataService;
+
+  constructor(containerMetadataService: ContainerMetadataService) {
+    this.#containerMetadataService = containerMetadataService;
+  }
+
+  public getBindingMetadata<TInstance, TArgs extends unknown[]>(
+    type: Newable<TInstance, TArgs>,
+  ): TypeBindingApi<TInstance, TArgs> | undefined {
+    const typeBinding: TypeBinding<TInstance, TArgs> | undefined =
+      this.#containerMetadataService.getBindingMetadata(type);
+
+    return typeBinding === undefined
+      ? undefined
+      : convertBindingToBindingApi(typeBinding);
+  }
+
+  public getClassMetadata<TInstance, TArgs extends unknown[]>(
+    type: Newable<TInstance, TArgs>,
+  ): ClassMetadataApi {
+    const classMetadata: ClassMetadata =
+      this.#containerMetadataService.getClassMetadata(type);
+
+    return convertClassMetadataToClassMetadataApi(classMetadata);
+  }
+}

--- a/packages/iocuak/src/metadata/models/api/ClassMetadataApi.ts
+++ b/packages/iocuak/src/metadata/models/api/ClassMetadataApi.ts
@@ -1,0 +1,6 @@
+import { ServiceId } from '../../../common/models/domain/ServiceId';
+
+export interface ClassMetadataApi {
+  constructorArguments: ServiceId[];
+  properties: Map<string | symbol, ServiceId>;
+}

--- a/packages/iocuak/src/metadata/utils/api/convertClassMetadataToClassMetadataApi.spec.ts
+++ b/packages/iocuak/src/metadata/utils/api/convertClassMetadataToClassMetadataApi.spec.ts
@@ -1,0 +1,29 @@
+import { ClassMetadataApi } from '../../models/api/ClassMetadataApi';
+import { ClassMetadata } from '../../models/domain/ClassMetadata';
+import { convertClassMetadataToClassMetadataApi } from './convertClassMetadataToClassMetadataApi';
+
+describe(convertClassMetadataToClassMetadataApi.name, () => {
+  describe('when called', () => {
+    let classMetadataFixture: ClassMetadata;
+    let classMetadataApiFixture: ClassMetadataApi;
+    let result: unknown;
+
+    beforeAll(() => {
+      classMetadataFixture = {
+        constructorArguments: ['ctor-first-service-id'],
+        properties: new Map([['foo', Symbol.for('bar')]]),
+      };
+
+      classMetadataApiFixture = {
+        constructorArguments: ['ctor-first-service-id'],
+        properties: new Map([['foo', Symbol.for('bar')]]),
+      };
+
+      result = convertClassMetadataToClassMetadataApi(classMetadataFixture);
+    });
+
+    it('should return ClassMetadataApi', () => {
+      expect(result).toStrictEqual(classMetadataApiFixture);
+    });
+  });
+});

--- a/packages/iocuak/src/metadata/utils/api/convertClassMetadataToClassMetadataApi.ts
+++ b/packages/iocuak/src/metadata/utils/api/convertClassMetadataToClassMetadataApi.ts
@@ -1,0 +1,11 @@
+import { ClassMetadataApi } from '../../models/api/ClassMetadataApi';
+import { ClassMetadata } from '../../models/domain/ClassMetadata';
+
+export function convertClassMetadataToClassMetadataApi(
+  classMetadata: ClassMetadata,
+): ClassMetadataApi {
+  return {
+    constructorArguments: [...classMetadata.constructorArguments],
+    properties: new Map(classMetadata.properties),
+  };
+}


### PR DESCRIPTION
### Added
- Added `ClassMetadataApi`.
- Added `convertClassMetadataToClassMetadataApi`.
- Added `MetadataApiService`.
- Added `MetadataApiServiceImplementation`.