### PR TITLE
Fix build clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc --build tsconfig.packages.json",
     "build:dev": "tsc --build tsconfig.packages.dev.json",
-    "build:clean": "tsc --build tsconfig.packages.json --clean",
+    "build:clean": "node ./scripts/removeTypescriptCompiledFiles.mjs",
     "commit": "commit",
     "format": "prettier --write ./packages",
     "lint": "eslint --ext ts --ignore-path .gitignore .",
@@ -61,6 +61,7 @@
     "lint-staged": "^12.3.7",
     "prettier": "^2.6.1",
     "reflect-metadata": "^0.1.13",
+    "rimraf": "^3.0.2",
     "sqlite3": "^5.0.2",
     "ts-jest": "^27.1.3",
     "ts-node": "^10.7.0",

--- a/packages/cuaktask/tsconfig.dev.json
+++ b/packages/cuaktask/tsconfig.dev.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "incremental": true
+    "incremental": true,
+    "tsBuildInfoFile": "./lib/tsconfig.dev.tsbuildinfo"
   }
 }

--- a/packages/cuaktask/tsconfig.json
+++ b/packages/cuaktask/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./lib/tsconfig.tsbuildinfo"
   },
   "include": ["src"]
 }

--- a/packages/iocuak/tsconfig.dev.json
+++ b/packages/iocuak/tsconfig.dev.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "incremental": true
+    "incremental": true,
+    "tsBuildInfoFile": "./lib/tsconfig.dev.tsbuildinfo"
   }
 }

--- a/packages/iocuak/tsconfig.json
+++ b/packages/iocuak/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./lib/tsconfig.tsbuildinfo"
   },
   "include": ["src"]
 }

--- a/packages/porygon-typeorm/tsconfig.dev.json
+++ b/packages/porygon-typeorm/tsconfig.dev.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "incremental": true
+    "incremental": true,
+    "tsBuildInfoFile": "./lib/tsconfig.dev.tsbuildinfo"
   }
 }

--- a/packages/porygon-typeorm/tsconfig.json
+++ b/packages/porygon-typeorm/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./lib/tsconfig.tsbuildinfo"
   },
   "include": ["src"]
 }

--- a/packages/porygon/tsconfig.dev.json
+++ b/packages/porygon/tsconfig.dev.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "incremental": true
+    "incremental": true,
+    "tsBuildInfoFile": "./lib/tsconfig.dev.tsbuildinfo"
   }
 }

--- a/packages/porygon/tsconfig.json
+++ b/packages/porygon/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./lib/tsconfig.tsbuildinfo"
   },
   "include": ["src"]
 }

--- a/scripts/removeTypescriptCompiledFiles.mjs
+++ b/scripts/removeTypescriptCompiledFiles.mjs
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import path from 'path';
+import url from 'url';
+
+import rimraf from 'rimraf';
+
+/**
+ * Deletes a directory recursively
+ * @param {string} path path to directory to delete
+ * @returns {Promise.<void>}
+ */
+async function rimrafAsync(path) {
+  return new Promise((resolve, reject) => {
+    rimraf(path, (error) => {
+      if (error == null) {
+        resolve();
+      } else {
+        reject(error);
+      }
+    });
+  });
+}
+
+/**
+ * Deletes multiple directories recursively
+ * @param {Array.<string>} directories direcotries to delete
+ * @returns {Promise.<void>}
+ */
+async function deleteDirectoriesRecursively(directories) {
+  await Promise.all(
+    directories.map(async (directory) => rimrafAsync(directory)),
+  );
+}
+
+async function main() {
+  const __filename = url.fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+
+  const packagesDirectory = path.resolve(__dirname, '..', 'packages');
+  const packageDirectoryNames = fs.readdirSync(packagesDirectory);
+
+  const packageCompiledFilesDirectories = packageDirectoryNames.map(
+    (packageDirectoryName) =>
+      path.resolve(packagesDirectory, packageDirectoryName, 'lib'),
+  );
+
+  await deleteDirectoriesRecursively(packageCompiledFilesDirectories);
+}
+
+await main();


### PR DESCRIPTION
### Added
- Added `removeTypescriptCompiledFiles` script.

### Changed
- Updated `build:clean` script to use `removeTypescriptCompiledFiles` script.
- Updated typescript packages config to build info files in the compiled files directory