### PR TITLE
Update task builder to not require set like

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,17 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
         if: ${{ !(github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) }}
 
+      - name: Start SSH session on failure
+        if: ${{ failure() }}
+        uses: luchihoratiu/debug-via-ssh@main
+        with:
+          NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
+          SSH_PASS: ${{ secrets.SSH_PASS }}
+
+      - name: Don't kill instace on failure
+        if: ${{ failure() }}
+        run: sleep 1h
+
   test-coverage:
     name: Test with coverage
     needs: test-coverage-package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,14 +134,14 @@ jobs:
         if: ${{ !(github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true) }}
 
       - name: Start SSH session on failure
-        if: ${{ failure() }}
+        if: ${{ failure() && contains(github.event.head_commit.message, '[ci-open-ssh]') }}
         uses: luchihoratiu/debug-via-ssh@main
         with:
           NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}
           SSH_PASS: ${{ secrets.SSH_PASS }}
 
       - name: Don't kill instace on failure
-        if: ${{ failure() }}
+        if: ${{ failure() && contains(github.event.head_commit.message, '[ci-open-ssh]') }}
         run: sleep 1h
 
   test-coverage:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,8 @@ jobs:
       - uses: pnpm/action-setup@v2.1.0
         with:
           version: 6.31.0
-          run_install: true
+          run_install:
+            recursive: true
 
       - name: Compile source files
         run: pnpm run build

--- a/docs/release-version.md
+++ b/docs/release-version.md
@@ -16,6 +16,10 @@ npm login
 
 4. Publish all the packages
 
+**Warning**: the use of `pnpm workspaces` forces us to publish packages through `pnpm publish`
+
 ```
-pnpm run publish:packages
+pnpm run prepublish:packages
 ```
+
+Then, for each package, navigate to the package folder and run `pnpm publish`

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@commitlint/config-conventional": "^16.2.1",
     "@commitlint/prompt-cli": "^16.2.3",
     "@types/jest": "^27.4.1",
+    "@types/node": "^16.11.26",
     "@typescript-eslint/eslint-plugin": "^5.16.0",
     "@typescript-eslint/parser": "^5.16.0",
     "eslint": "^8.11.0",
@@ -76,8 +77,5 @@
       "prettier --write",
       "eslint"
     ]
-  },
-  "dependencies": {
-    "@types/node": "^16.11.26"
   }
 }

--- a/packages/cuaktask/CHANGELOG.md
+++ b/packages/cuaktask/CHANGELOG.md
@@ -19,6 +19,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
+## [UNRELEASED]
+
+### Added
+- Added `SafeDependentTaskBuilder`
+
+### Changed
+- **[BC]** Updated `TaskDependencyBuilder` to no longer receive a set builder. Use `SafeDependentTaskBuilder` as replacement for the old `TaskDependencyBuilder`
+
+
+
+
 ## 0.1.0
 
 ### Changed

--- a/packages/cuaktask/docs/index.md
+++ b/packages/cuaktask/docs/index.md
@@ -4,10 +4,10 @@ Welcome to cuaktask's docs. This pages explains how to use the library to create
 
 ## Contents
 
-1. [Introduction](./contents/1-introduction).
-2. [The big picture](./contents/2-the-big-picture).
-3. [About tasks](./contents/3-about-tasks).
-4. [About task dependency engines](./contents/4-about-task-dependency-engines).
-5. [About task builders](./contents/5-about-task-builders).
+1. [Introduction](./contents/1-introduction.md).
+2. [The big picture](./contents/2-the-big-picture.md).
+3. [About tasks](./contents/3-about-tasks.md).
+4. [About task dependency engines](./contents/4-about-task-dependency-engines.md).
+5. [About task builders](./contents/5-about-task-builders.md).
 
-In addition, API docs are available [here](./api/index).
+In addition, API docs are available [here](./api/index.md).

--- a/packages/cuaktask/src/index.ts
+++ b/packages/cuaktask/src/index.ts
@@ -7,6 +7,7 @@ import { Task } from './task/models/domain/Task';
 import { TaskStatus } from './task/models/domain/TaskStatus';
 import { DependentTaskBuilder } from './task/modules/DependentTaskBuilder';
 import { DependentTaskRunner } from './task/modules/DependentTaskRunner';
+import { SafeDependentTaskBuilder } from './task/modules/SafeDependentTaskBuilder';
 import { TaskDependencyEngine } from './task/modules/TaskDependencyEngine';
 
 export type { Builder, DependentTask, SetLike, Task, TaskDependencyEngine };
@@ -16,5 +17,6 @@ export {
   BaseTask,
   DependentTaskBuilder,
   DependentTaskRunner,
+  SafeDependentTaskBuilder,
   TaskStatus,
 };

--- a/packages/cuaktask/src/task/modules/DependentTaskBuildOperation.spec.ts
+++ b/packages/cuaktask/src/task/modules/DependentTaskBuildOperation.spec.ts
@@ -1,0 +1,160 @@
+import { Builder } from '../../common/modules/Builder';
+import { DependentTask } from '../models/domain/DependentTask';
+import { TaskStatus } from '../models/domain/TaskStatus';
+import { DependentTaskBuilder } from './DependentTaskBuilder';
+import { DependentTaskBuildOperation } from './DependentTaskBuildOperation';
+import { TaskDependencyEngine } from './TaskDependencyEngine';
+
+describe(DependentTaskBuilder.name, () => {
+  let taskWithNoDependenciesBuilderMock: jest.Mocked<
+    Builder<DependentTask<unknown>, [unknown]>
+  >;
+  let taskDependencyEngine: jest.Mocked<TaskDependencyEngine>;
+
+  let dependentTaskBuildOperation: DependentTaskBuildOperation;
+
+  beforeAll(() => {
+    taskWithNoDependenciesBuilderMock = {
+      build: jest.fn<DependentTask<unknown>, [unknown]>(),
+    };
+    taskDependencyEngine = {
+      getDependencies: jest.fn(),
+    };
+
+    dependentTaskBuildOperation = new DependentTaskBuildOperation(
+      taskWithNoDependenciesBuilderMock,
+      taskDependencyEngine,
+    );
+  });
+
+  describe('.run()', () => {
+    describe('when called, with no dependencies', () => {
+      let taskKindFixture: string;
+      let taskFixture: DependentTask<string, unknown, unknown[], unknown>;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        taskKindFixture = 'some-kind';
+        taskFixture = {
+          dependencies: [],
+          kind: taskKindFixture,
+          perform: jest.fn(),
+          status: TaskStatus.NotStarted,
+        };
+
+        taskWithNoDependenciesBuilderMock.build.mockReturnValueOnce(
+          taskFixture,
+        );
+        taskDependencyEngine.getDependencies.mockReturnValueOnce([]);
+
+        result = dependentTaskBuildOperation.run(taskKindFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call taskWithNoDependenciesBuilderMock.build()', () => {
+        expect(taskWithNoDependenciesBuilderMock.build).toHaveBeenCalledTimes(
+          1,
+        );
+        expect(taskWithNoDependenciesBuilderMock.build).toHaveBeenCalledWith(
+          taskKindFixture,
+        );
+      });
+
+      it('should call taskDependencyEngine.getDependencies()', () => {
+        expect(taskDependencyEngine.getDependencies).toHaveBeenCalledTimes(1);
+        expect(taskDependencyEngine.getDependencies).toHaveBeenCalledWith(
+          taskKindFixture,
+        );
+      });
+
+      it('should return a dependent task', () => {
+        const expected: DependentTask<string, unknown, unknown[], unknown> = {
+          ...taskFixture,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('when called, with dependencies', () => {
+    let dependentTaskKindFixture: string;
+    let dependentTaskFixture: DependentTask<
+      string,
+      unknown,
+      unknown[],
+      unknown
+    >;
+    let taskKindFixture: string;
+    let taskFixture: DependentTask<string, unknown, unknown[], unknown>;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      dependentTaskKindFixture = 'dependent-kind';
+      dependentTaskFixture = {
+        dependencies: [],
+        kind: dependentTaskKindFixture,
+        perform: jest.fn(),
+        status: TaskStatus.NotStarted,
+      };
+      taskKindFixture = 'some-kind';
+      taskFixture = {
+        dependencies: [],
+        kind: taskKindFixture,
+        perform: jest.fn(),
+        status: TaskStatus.NotStarted,
+      };
+
+      taskWithNoDependenciesBuilderMock.build
+        .mockReturnValueOnce(taskFixture)
+        .mockReturnValueOnce(dependentTaskFixture);
+      taskDependencyEngine.getDependencies
+        .mockReturnValueOnce([dependentTaskKindFixture])
+        .mockReturnValueOnce([]);
+
+      result = dependentTaskBuildOperation.run(taskKindFixture);
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call taskWithNoDependenciesBuilderMock.build()', () => {
+      expect(taskWithNoDependenciesBuilderMock.build).toHaveBeenCalledTimes(2);
+      expect(taskWithNoDependenciesBuilderMock.build).toHaveBeenNthCalledWith(
+        1,
+        taskKindFixture,
+      );
+      expect(taskWithNoDependenciesBuilderMock.build).toHaveBeenNthCalledWith(
+        2,
+        dependentTaskKindFixture,
+      );
+    });
+
+    it('should call taskDependencyEngine.getDependencies()', () => {
+      expect(taskDependencyEngine.getDependencies).toHaveBeenCalledTimes(2);
+      expect(taskDependencyEngine.getDependencies).toHaveBeenNthCalledWith(
+        1,
+        taskKindFixture,
+      );
+      expect(taskDependencyEngine.getDependencies).toHaveBeenNthCalledWith(
+        2,
+        dependentTaskKindFixture,
+      );
+    });
+
+    it('should return a dependent task', () => {
+      const expected: DependentTask<string, unknown, unknown[], unknown> = {
+        ...taskFixture,
+        dependencies: [dependentTaskFixture],
+      };
+
+      expect(result).toStrictEqual(expected);
+    });
+  });
+});

--- a/packages/cuaktask/src/task/modules/DependentTaskBuildOperation.ts
+++ b/packages/cuaktask/src/task/modules/DependentTaskBuildOperation.ts
@@ -1,0 +1,64 @@
+import { Builder } from '../../common/modules/Builder';
+import { DependentTask } from '../models/domain/DependentTask';
+import { TaskDependencyEngine } from './TaskDependencyEngine';
+
+export class DependentTaskBuildOperation<
+  TKind = unknown,
+  TArgs extends unknown[] = unknown[],
+  TReturn = unknown,
+> {
+  readonly #taskWithNoDependenciesBuilder: Builder<
+    DependentTask<TKind, unknown, TArgs, TReturn>,
+    [TKind]
+  >;
+  readonly #taskDependencyEngine: TaskDependencyEngine;
+
+  constructor(
+    taskWithNoDependenciesBuilder: Builder<
+      DependentTask<TKind, unknown, TArgs, TReturn>,
+      [TKind]
+    >,
+    taskDependencyEngine: TaskDependencyEngine,
+  ) {
+    this.#taskWithNoDependenciesBuilder = taskWithNoDependenciesBuilder;
+    this.#taskDependencyEngine = taskDependencyEngine;
+  }
+
+  /**
+   * Builds a task.
+   * @param taskKind Task kind of the task to build
+   * @returns Task built.
+   */
+  public run(taskKind: TKind): DependentTask<TKind, TKind, TArgs, TReturn> {
+    const dependentTask: DependentTask<TKind, TKind, TArgs, TReturn> =
+      this.build(taskKind);
+
+    return dependentTask;
+  }
+
+  protected build(
+    taskKind: TKind,
+  ): DependentTask<TKind, TKind, TArgs, TReturn> {
+    const task: DependentTask<TKind, unknown, TArgs, TReturn> =
+      this.#taskWithNoDependenciesBuilder.build(taskKind);
+
+    const taskDependencies: DependentTask<TKind>[] = this.buildDependencies(
+      task.kind,
+    );
+
+    task.dependencies.push(...taskDependencies);
+
+    return task;
+  }
+
+  protected buildDependencies(taskKind: TKind): DependentTask<TKind>[] {
+    const taskDependenciesKind: TKind[] =
+      this.#taskDependencyEngine.getDependencies(taskKind);
+
+    const taskDependencies: DependentTask<TKind>[] = taskDependenciesKind.map(
+      (taskDependencyKind: TKind) => this.build(taskDependencyKind),
+    );
+
+    return taskDependencies;
+  }
+}

--- a/packages/cuaktask/src/task/modules/SafeDependentTaskBuildOperation.spec.ts
+++ b/packages/cuaktask/src/task/modules/SafeDependentTaskBuildOperation.spec.ts
@@ -1,0 +1,173 @@
+import { Builder } from '../../common/modules/Builder';
+import { SetLike } from '../../common/modules/SetLike';
+import { DependentTask } from '../models/domain/DependentTask';
+import { TaskStatus } from '../models/domain/TaskStatus';
+import { DependentTaskBuilder } from './DependentTaskBuilder';
+import { SafeDependentTaskBuildOperation } from './SafeDependentTaskBuildOperation';
+import { TaskDependencyEngine } from './TaskDependencyEngine';
+
+describe(DependentTaskBuilder.name, () => {
+  let taskWithNoDependenciesBuilderMock: jest.Mocked<
+    Builder<DependentTask<unknown>, [unknown]>
+  >;
+  let taskDependencyEngine: jest.Mocked<TaskDependencyEngine>;
+  let taskDependenciesKindSet: jest.Mocked<SetLike<unknown>>;
+  let safeDependentTaskBuildOperation: SafeDependentTaskBuildOperation;
+
+  beforeAll(() => {
+    taskWithNoDependenciesBuilderMock = {
+      build: jest.fn<DependentTask<unknown>, [unknown]>(),
+    };
+    taskDependencyEngine = {
+      getDependencies: jest.fn(),
+    };
+    taskDependenciesKindSet = {
+      add: jest.fn(),
+      clear: jest.fn(),
+      delete: jest.fn(),
+      has: jest.fn(),
+    };
+
+    safeDependentTaskBuildOperation = new SafeDependentTaskBuildOperation(
+      taskWithNoDependenciesBuilderMock,
+      taskDependencyEngine,
+      taskDependenciesKindSet,
+    );
+  });
+
+  describe('.build()', () => {
+    describe('when called, with no circular dependencies', () => {
+      let dependentTaskKindFixture: string;
+      let dependentTaskFixture: DependentTask<
+        string,
+        unknown,
+        unknown[],
+        unknown
+      >;
+      let taskKindFixture: string;
+      let taskFixture: DependentTask<string, unknown, unknown[], unknown>;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        dependentTaskKindFixture = 'dependent-kind';
+        dependentTaskFixture = {
+          dependencies: [],
+          kind: dependentTaskKindFixture,
+          perform: jest.fn(),
+          status: TaskStatus.NotStarted,
+        };
+        taskKindFixture = 'some-kind';
+        taskFixture = {
+          dependencies: [],
+          kind: taskKindFixture,
+          perform: jest.fn(),
+          status: TaskStatus.NotStarted,
+        };
+
+        taskDependenciesKindSet.has
+          .mockReturnValueOnce(false)
+          .mockReturnValueOnce(false);
+
+        taskWithNoDependenciesBuilderMock.build
+          .mockReturnValueOnce(taskFixture)
+          .mockReturnValueOnce(dependentTaskFixture);
+        taskDependencyEngine.getDependencies
+          .mockReturnValueOnce([dependentTaskKindFixture])
+          .mockReturnValueOnce([]);
+
+        result = safeDependentTaskBuildOperation.run(taskKindFixture);
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call taskDependenciesKindSet.has()', () => {
+        expect(taskDependenciesKindSet.has).toHaveBeenCalledTimes(2);
+        expect(taskDependenciesKindSet.has).toHaveBeenNthCalledWith(
+          1,
+          taskKindFixture,
+        );
+        expect(taskDependenciesKindSet.has).toHaveBeenNthCalledWith(
+          2,
+          dependentTaskKindFixture,
+        );
+      });
+
+      it('should call taskWithNoDependenciesBuilderMock.build()', () => {
+        expect(taskWithNoDependenciesBuilderMock.build).toHaveBeenCalledTimes(
+          2,
+        );
+        expect(taskWithNoDependenciesBuilderMock.build).toHaveBeenNthCalledWith(
+          1,
+          taskKindFixture,
+        );
+        expect(taskWithNoDependenciesBuilderMock.build).toHaveBeenNthCalledWith(
+          2,
+          dependentTaskKindFixture,
+        );
+      });
+
+      it('should call taskDependencyEngine.getDependencies()', () => {
+        expect(taskDependencyEngine.getDependencies).toHaveBeenCalledTimes(2);
+        expect(taskDependencyEngine.getDependencies).toHaveBeenNthCalledWith(
+          1,
+          taskKindFixture,
+        );
+        expect(taskDependencyEngine.getDependencies).toHaveBeenNthCalledWith(
+          2,
+          dependentTaskKindFixture,
+        );
+      });
+
+      it('should return a dependent task', () => {
+        const expected: DependentTask<string, unknown, unknown[], unknown> = {
+          ...taskFixture,
+          dependencies: [dependentTaskFixture],
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('when called, with circular dependencies', () => {
+    let dependentTaskKindFixture: string;
+    let taskKindFixture: string;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      dependentTaskKindFixture = 'dependent-kind';
+
+      taskKindFixture = dependentTaskKindFixture;
+
+      taskDependenciesKindSet.has.mockReturnValueOnce(true);
+
+      try {
+        safeDependentTaskBuildOperation.run(taskKindFixture);
+      } catch (error: unknown) {
+        result = error;
+      }
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call taskDependenciesKindSet.has()', () => {
+      expect(taskDependenciesKindSet.has).toHaveBeenCalledTimes(1);
+      expect(taskDependenciesKindSet.has).toHaveBeenCalledWith(taskKindFixture);
+    });
+
+    it('should throw an Error', () => {
+      expect(result).toBeInstanceOf(Error);
+      expect(result).toStrictEqual(
+        expect.objectContaining<Partial<Error>>({
+          message: 'Circular dependency found!',
+        }),
+      );
+    });
+  });
+});

--- a/packages/cuaktask/src/task/modules/SafeDependentTaskBuildOperation.ts
+++ b/packages/cuaktask/src/task/modules/SafeDependentTaskBuildOperation.ts
@@ -1,0 +1,54 @@
+import { Builder } from '../../common/modules/Builder';
+import { SetLike } from '../../common/modules/SetLike';
+import { DependentTask } from '../models/domain/DependentTask';
+import { DependentTaskBuildOperation } from './DependentTaskBuildOperation';
+import { TaskDependencyEngine } from './TaskDependencyEngine';
+
+export class SafeDependentTaskBuildOperation<
+  TKind = unknown,
+  TArgs extends unknown[] = unknown[],
+  TReturn = unknown,
+> extends DependentTaskBuildOperation<TKind, TArgs, TReturn> {
+  readonly #taskDependenciesKindSet: SetLike<TKind>;
+
+  constructor(
+    taskWithNoDependenciesBuilder: Builder<
+      DependentTask<TKind, unknown, TArgs, TReturn>,
+      [TKind]
+    >,
+    taskDependencyEngine: TaskDependencyEngine,
+    taskDependenciesKindSet: SetLike<TKind>,
+  ) {
+    super(taskWithNoDependenciesBuilder, taskDependencyEngine);
+
+    this.#taskDependenciesKindSet = taskDependenciesKindSet;
+  }
+
+  protected override build(
+    taskKind: TKind,
+  ): DependentTask<TKind, TKind, TArgs, TReturn> {
+    if (this.#taskDependenciesKindSet.has(taskKind)) {
+      throw new Error('Circular dependency found!');
+    }
+
+    const task: DependentTask<TKind, unknown, TArgs, TReturn> = super.build(
+      taskKind,
+    );
+
+    return task;
+  }
+
+  protected override buildDependencies(
+    taskKind: TKind,
+  ): DependentTask<TKind>[] {
+    this.#taskDependenciesKindSet.add(taskKind);
+
+    const taskDependencies: DependentTask<TKind>[] = super.buildDependencies(
+      taskKind,
+    );
+
+    this.#taskDependenciesKindSet.delete(taskKind);
+
+    return taskDependencies;
+  }
+}

--- a/packages/cuaktask/src/task/modules/SafeDependentTaskBuilder.ts
+++ b/packages/cuaktask/src/task/modules/SafeDependentTaskBuilder.ts
@@ -1,0 +1,44 @@
+import { Builder } from '../../common/modules/Builder';
+import { SetLike } from '../../common/modules/SetLike';
+import { DependentTaskBuilder } from './DependentTaskBuilder';
+import { DependentTaskBuildOperation } from './DependentTaskBuildOperation';
+import { SafeDependentTaskBuildOperation } from './SafeDependentTaskBuildOperation';
+import { TaskDependencyEngine } from './TaskDependencyEngine';
+
+export abstract class SafeDependentTaskBuilder<
+  TKind = unknown,
+  TArgs extends unknown[] = unknown[],
+  TReturn = unknown,
+> extends DependentTaskBuilder<TKind, TArgs, TReturn> {
+  readonly #taskDependenciesKindSetBuilder: Builder<SetLike<TKind>>;
+
+  constructor(
+    taskDependencyEngine: TaskDependencyEngine,
+    taskDependenciesKindSetBuilder: Builder<SetLike<TKind>>,
+  ) {
+    super(taskDependencyEngine);
+
+    this.#taskDependenciesKindSetBuilder = taskDependenciesKindSetBuilder;
+  }
+
+  protected override buildDependentTaskBuildOperation(): DependentTaskBuildOperation<
+    TKind,
+    TArgs,
+    TReturn
+  > {
+    const taskDependenciesKindSet: SetLike<TKind> =
+      this.#taskDependenciesKindSetBuilder.build();
+
+    const dependentTaskBuildOperation: DependentTaskBuildOperation<
+      TKind,
+      TArgs,
+      TReturn
+    > = new SafeDependentTaskBuildOperation(
+      this.taskWithNoDependenciesBuilder,
+      this.taskDependencyEngine,
+      taskDependenciesKindSet,
+    );
+
+    return dependentTaskBuildOperation;
+  }
+}

--- a/packages/cuaktask/tsconfig.dev.json
+++ b/packages/cuaktask/tsconfig.dev.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "incremental": true,

--- a/packages/cuaktask/tsconfig.json
+++ b/packages/cuaktask/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib",

--- a/packages/iocuak/package.json
+++ b/packages/iocuak/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/cuaklabs/cuaktask/tree/master/packages/iocuak#readme",
   "dependencies": {
-    "@cuaklabs/cuaktask": "^0.1.1"
+    "@cuaklabs/cuaktask": "workspace:../cuaktask"
   },
   "gitHead": "e711d2cccc0ae863eed676a4c496813c6aa481e4",
   "publishConfig": {

--- a/packages/iocuak/src/container/modules/api/ContainerApi.ts
+++ b/packages/iocuak/src/container/modules/api/ContainerApi.ts
@@ -92,21 +92,21 @@ export class ContainerApi extends ContainerServiceApiImplementation {
     containerRequestService: ContainerRequestService,
     containerSingletonService: ContainerSingletonService,
   ) {
+    const taskDependencyEngine: cuaktask.TaskDependencyEngine =
+      new TaskDependencyEngine(containerBindingService, metadataService);
+
     const taskDependenciesKindSetBuilder: cuaktask.Builder<
       cuaktask.SetLike<TaskKind>
     > = {
       build: () => new TaskKindSet(),
     };
 
-    const taskDependencyEngine: cuaktask.TaskDependencyEngine =
-      new TaskDependencyEngine(containerBindingService, metadataService);
-
     const taskBuilder: cuaktask.Builder<
       cuaktask.DependentTask<TaskKind, TaskKind>,
       [TaskKind]
     > = new TaskBuilder(
-      taskDependenciesKindSetBuilder,
       taskDependencyEngine,
+      taskDependenciesKindSetBuilder,
       containerBindingService,
       containerRequestService,
       containerSingletonService,

--- a/packages/iocuak/src/container/modules/api/ContainerApi.ts
+++ b/packages/iocuak/src/container/modules/api/ContainerApi.ts
@@ -70,7 +70,7 @@ export class ContainerApi extends ContainerServiceApiImplementation {
     const taskBuilder: cuaktask.Builder<
       cuaktask.DependentTask<TaskKind, TaskKind>,
       [TaskKind]
-    > = this.#initializeTaskRunner(
+    > = this.#initializeTaskBuilder(
       containerBindingService,
       metadataService,
       containerRequestService,
@@ -86,7 +86,7 @@ export class ContainerApi extends ContainerServiceApiImplementation {
     return containerInstanceService;
   }
 
-  static #initializeTaskRunner(
+  static #initializeTaskBuilder(
     containerBindingService: ContainerBindingService,
     metadataService: MetadataService,
     containerRequestService: ContainerRequestService,

--- a/packages/iocuak/src/task/modules/TaskBuilder.spec.ts
+++ b/packages/iocuak/src/task/modules/TaskBuilder.spec.ts
@@ -16,8 +16,8 @@ import { TaskKind } from '../models/domain/TaskKind';
 import { TaskBuilder } from './TaskBuilder';
 
 describe(TaskBuilder.name, () => {
-  let taskDependenciesKindSetBuilder: jest.Mocked<Builder<SetLike<TaskKind>>>;
   let taskDependencyEngine: jest.Mocked<TaskDependencyEngine>;
+  let taskDependenciesKindSetBuilder: jest.Mocked<Builder<SetLike<TaskKind>>>;
   let containerBindingServiceMock: jest.Mocked<ContainerBindingService>;
   let containerRequestService: jest.Mocked<ContainerRequestService>;
   let containerSingletonServiceMock: jest.Mocked<ContainerSingletonService>;
@@ -25,11 +25,11 @@ describe(TaskBuilder.name, () => {
   let taskBuilder: TaskBuilder;
 
   beforeAll(() => {
-    taskDependenciesKindSetBuilder = {
-      build: jest.fn().mockImplementation(() => new Set()),
-    };
     taskDependencyEngine = {
       getDependencies: jest.fn(),
+    };
+    taskDependenciesKindSetBuilder = {
+      build: jest.fn().mockImplementation(() => new Set()),
     };
     containerBindingServiceMock = {} as Partial<
       jest.Mocked<ContainerBindingService>
@@ -42,8 +42,8 @@ describe(TaskBuilder.name, () => {
     > as jest.Mocked<ContainerSingletonService>;
 
     taskBuilder = new TaskBuilder(
-      taskDependenciesKindSetBuilder,
       taskDependencyEngine,
+      taskDependenciesKindSetBuilder,
       containerBindingServiceMock,
       containerRequestService,
       containerSingletonServiceMock,

--- a/packages/iocuak/src/task/modules/TaskBuilder.ts
+++ b/packages/iocuak/src/task/modules/TaskBuilder.ts
@@ -1,7 +1,7 @@
 import {
   Builder,
   DependentTask,
-  DependentTaskBuilder,
+  SafeDependentTaskBuilder,
   SetLike,
   TaskDependencyEngine,
 } from '@cuaklabs/cuaktask';
@@ -17,19 +17,19 @@ import { GetInstanceDependenciesTaskKind } from '../models/domain/GetInstanceDep
 import { TaskKind } from '../models/domain/TaskKind';
 import { TaskKindType } from '../models/domain/TaskKindType';
 
-export class TaskBuilder extends DependentTaskBuilder<TaskKind, TaskKind> {
+export class TaskBuilder extends SafeDependentTaskBuilder<TaskKind> {
   #containerBindingService: ContainerBindingService;
   #containerRequestService: ContainerRequestService;
   #containerSingletonService: ContainerSingletonService;
 
   constructor(
-    taskDependenciesKindSetBuilder: Builder<SetLike<TaskKind>>,
     taskDependencyEngine: TaskDependencyEngine,
+    taskDependenciesKindSetBuilder: Builder<SetLike<TaskKind>>,
     containerBindingService: ContainerBindingService,
     containerRequestService: ContainerRequestService,
     containerSingletonService: ContainerSingletonService,
   ) {
-    super(taskDependenciesKindSetBuilder, taskDependencyEngine);
+    super(taskDependencyEngine, taskDependenciesKindSetBuilder);
 
     this.#containerBindingService = containerBindingService;
     this.#containerRequestService = containerRequestService;

--- a/packages/iocuak/tsconfig.dev.json
+++ b/packages/iocuak/tsconfig.dev.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "incremental": true,

--- a/packages/iocuak/tsconfig.json
+++ b/packages/iocuak/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib",

--- a/packages/porygon-typeorm/package.json
+++ b/packages/porygon-typeorm/package.json
@@ -20,8 +20,8 @@
   },
   "homepage": "https://github.com/cuaklabs/cuaktask/tree/master/packages/porygon-typeorm#readme",
   "dependencies": {
-    "@cuaklabs/iocuak": "^0.1.1",
-    "@cuaklabs/porygon": "^0.1.1",
+    "@cuaklabs/iocuak": "workspace:../iocuak",
+    "@cuaklabs/porygon": "workspace:../porygon",
     "typeorm": "^0.3.3"
   },
   "devDependencies": {

--- a/packages/porygon-typeorm/tsconfig.dev.json
+++ b/packages/porygon-typeorm/tsconfig.dev.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "incremental": true,

--- a/packages/porygon-typeorm/tsconfig.json
+++ b/packages/porygon-typeorm/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib",

--- a/packages/porygon/package.json
+++ b/packages/porygon/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/cuaklabs/cuaktask/tree/master/packages/porygon#readme",
   "dependencies": {
-    "@cuaklabs/iocuak": "^0.1.1"
+    "@cuaklabs/iocuak": "workspace:../iocuak"
   },
   "gitHead": "e711d2cccc0ae863eed676a4c496813c6aa481e4",
   "publishConfig": {

--- a/packages/porygon/tsconfig.dev.json
+++ b/packages/porygon/tsconfig.dev.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "incremental": true,

--- a/packages/porygon/tsconfig.json
+++ b/packages/porygon/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json.schemastore.org/tsconfig",
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./lib",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "composite": true,
     "experimentalDecorators": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,7 +15,9 @@
     "noUncheckedIndexedAccess": true,
     "paths": {
       "@cuaklabs/cuaktask": ["./packages/cuaktask"],
-      "@cuaklabs/iocuak": ["./packages/iocuak"]
+      "@cuaklabs/iocuak": ["./packages/iocuak"],
+      "@cuaklabs/porygon": ["./packages/porygon"],
+      "@cuaklabs/porygon-typeorm": ["./packages/porygon-typeorm"]
     },
     "resolveJsonModule": true,
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "http://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "experimentalDecorators": true,
     "esModuleInterop": true,


### PR DESCRIPTION
### Added
- Added `SafeDependentTaskBuilder`

### Changed
- **[BC]** Updated `TaskDependencyBuilder` to no longer receive a set builder. Use `SafeDependentTaskBuilder` as replacement for the old `TaskDependencyBuilder`