### PR TITLE
Fix task multiple execution

### DIFF
--- a/packages/cuaktask/CHANGELOG.md
+++ b/packages/cuaktask/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - **[BC]** Updated `TaskDependencyBuilder` to no longer receive a set builder. Use `SafeDependentTaskBuilder` as replacement for the old `TaskDependencyBuilder`
+- **[BC]** Updated `BaseTask` to throw an error if `perform` is called more than once.
+- Updated `BaseTask` with a `result` property.
 
 
 

--- a/packages/cuaktask/src/common/models/FlatPromise.ts
+++ b/packages/cuaktask/src/common/models/FlatPromise.ts
@@ -1,1 +1,3 @@
-export type FlatPromise<T> = Promise<T extends PromiseLike<infer U> ? U : T>;
+import { PromiseLikeResult } from './PromiseLikeResult';
+
+export type FlatPromise<T> = Promise<PromiseLikeResult<T>>;

--- a/packages/cuaktask/src/common/models/PromiseLikeResult.ts
+++ b/packages/cuaktask/src/common/models/PromiseLikeResult.ts
@@ -1,0 +1,1 @@
+export type PromiseLikeResult<T> = T extends PromiseLike<infer U> ? U : T;

--- a/packages/cuaktask/src/task/mocks/models/domain/DependentTaskMocks.ts
+++ b/packages/cuaktask/src/task/mocks/models/domain/DependentTaskMocks.ts
@@ -1,0 +1,70 @@
+import { DependentTask } from '../../../models/domain/DependentTask';
+import { TaskStatus } from '../../../models/domain/TaskStatus';
+import { TaskMocks } from './TaskMocks';
+
+export class DependentTaskMocks {
+  public static get any(): jest.Mocked<
+    DependentTask<unknown, unknown, unknown[], unknown>
+  > {
+    const mock: jest.Mocked<
+      DependentTask<unknown, unknown, unknown[], unknown>
+    > = {
+      ...TaskMocks.any,
+      dependencies: [],
+    };
+
+    return mock;
+  }
+
+  public static get withDependenciesEmpty(): jest.Mocked<
+    DependentTask<unknown, unknown, unknown[], unknown>
+  > {
+    const mock: jest.Mocked<
+      DependentTask<unknown, unknown, unknown[], unknown>
+    > = {
+      ...DependentTaskMocks.any,
+      dependencies: [],
+    };
+
+    return mock;
+  }
+
+  public static get withDependenciesEmptyAndStatusNotStarted(): jest.Mocked<
+    DependentTask<unknown, unknown, unknown[], unknown>
+  > {
+    const mock: jest.Mocked<
+      DependentTask<unknown, unknown, unknown[], unknown>
+    > = {
+      ...DependentTaskMocks.withDependenciesEmpty,
+      status: TaskStatus.NotStarted,
+    };
+
+    return mock;
+  }
+
+  public static get withStatusNotStarted(): jest.Mocked<
+    DependentTask<unknown, unknown, unknown[], unknown>
+  > {
+    const mock: jest.Mocked<
+      DependentTask<unknown, unknown, unknown[], unknown>
+    > = {
+      ...DependentTaskMocks.any,
+      status: TaskStatus.NotStarted,
+    };
+
+    return mock;
+  }
+
+  public static get withStatusEnded(): jest.Mocked<
+    DependentTask<unknown, unknown, unknown[], unknown>
+  > {
+    const mock: jest.Mocked<
+      DependentTask<unknown, unknown, unknown[], unknown>
+    > = {
+      ...DependentTaskMocks.any,
+      status: TaskStatus.Ended,
+    };
+
+    return mock;
+  }
+}

--- a/packages/cuaktask/src/task/mocks/models/domain/TaskMocks.ts
+++ b/packages/cuaktask/src/task/mocks/models/domain/TaskMocks.ts
@@ -1,0 +1,26 @@
+import { Task } from '../../../models/domain/Task';
+import { TaskStatus } from '../../../models/domain/TaskStatus';
+
+export class TaskMocks {
+  public static get any(): jest.Mocked<Task<unknown, unknown[], unknown>> {
+    const mock: jest.Mocked<Task<unknown, unknown[], unknown>> = {
+      kind: 'kind',
+      perform: jest.fn(),
+      result: undefined,
+      status: TaskStatus.NotStarted,
+    };
+
+    return mock;
+  }
+
+  public static get withStatusNothStarted(): jest.Mocked<
+    Task<unknown, unknown[], unknown>
+  > {
+    const mock: jest.Mocked<Task<unknown, unknown[], unknown>> = {
+      ...TaskMocks.any,
+      status: TaskStatus.NotStarted,
+    };
+
+    return mock;
+  }
+}

--- a/packages/cuaktask/src/task/models/domain/BaseDependentTask.ts
+++ b/packages/cuaktask/src/task/models/domain/BaseDependentTask.ts
@@ -1,4 +1,3 @@
-import { PromiseIfThenable } from '../../../common/models/PromiseIfThenable';
 import { BaseTask } from './BaseTask';
 import { DependentTask } from './DependentTask';
 
@@ -9,8 +8,7 @@ export abstract class BaseDependentTask<
     TReturn,
   >
   extends BaseTask<TKind, TArgs, TReturn>
-  implements
-    DependentTask<TKind, TDependencyKind, TArgs, PromiseIfThenable<TReturn>>
+  implements DependentTask<TKind, TDependencyKind, TArgs, TReturn>
 {
   protected _innerDependencies: DependentTask<TDependencyKind>[];
 

--- a/packages/cuaktask/src/task/models/domain/BaseTask.spec.ts
+++ b/packages/cuaktask/src/task/models/domain/BaseTask.spec.ts
@@ -32,6 +32,38 @@ describe(BaseTask.name, () => {
   });
 
   describe('.perform()', () => {
+    describe('when called, and innerPerform returns a syncronous result and .result is called', () => {
+      let baseTask: BaseTaskMock<string, [], unknown>;
+
+      let innerPerformResultFixture: unknown;
+      let result: unknown;
+
+      beforeAll(() => {
+        baseTask = new BaseTaskMock(kindFixture, innerPerformMock);
+
+        innerPerformResultFixture = {
+          foo: 'bar',
+        };
+        innerPerformMock.mockReturnValueOnce(innerPerformResultFixture);
+        baseTask.perform();
+
+        result = baseTask.result;
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call innerPerformMock', () => {
+        expect(innerPerformMock).toHaveBeenCalledTimes(1);
+        expect(innerPerformMock).toHaveBeenCalledWith();
+      });
+
+      it('should return a syncronous result', () => {
+        expect(result).toBe(innerPerformResultFixture);
+      });
+    });
+
     describe('when called, and innerPerform returns a syncronous result', () => {
       let baseTask: BaseTaskMock<string, [], unknown>;
 
@@ -97,6 +129,96 @@ describe(BaseTask.name, () => {
 
       it('should return an asyncronous result', () => {
         expect(result).toStrictEqual(innerPerformResultFixture);
+      });
+    });
+
+    describe('when called, and innerPerform returns a promise result, and .result is called before promise is resolved', () => {
+      let baseTask: BaseTaskMock<string, [], Promise<unknown>>;
+
+      let innerPerformResultFixture: unknown;
+      let firstCallResult: unknown;
+      let secondCallResult: unknown;
+
+      beforeAll(async () => {
+        baseTask = new BaseTaskMock(
+          kindFixture,
+          innerPerformMock as jest.Mock<Promise<unknown>, []>,
+        );
+
+        innerPerformResultFixture = {
+          foo: 'bar',
+        };
+
+        (
+          innerPerformMock as jest.Mock<Promise<unknown>, []>
+        ).mockResolvedValueOnce(innerPerformResultFixture);
+
+        firstCallResult = baseTask.perform();
+
+        secondCallResult = await baseTask.result;
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call innerPerformMock', () => {
+        expect(innerPerformMock).toHaveBeenCalledTimes(1);
+        expect(innerPerformMock).toHaveBeenCalledWith();
+      });
+
+      it('should return a result on first call', async () => {
+        await expect(firstCallResult).resolves.toStrictEqual(
+          innerPerformResultFixture,
+        );
+      });
+
+      it('should return a result on the second call', () => {
+        expect(secondCallResult).toStrictEqual(innerPerformResultFixture);
+      });
+    });
+
+    describe('when called, and innerPerform returns a promise result, and .result is called after promise is resolved', () => {
+      let baseTask: BaseTaskMock<string, [], Promise<unknown>>;
+
+      let innerPerformResultFixture: unknown;
+      let firstCallResult: unknown;
+      let secondCallResult: unknown;
+
+      beforeAll(async () => {
+        baseTask = new BaseTaskMock(
+          kindFixture,
+          innerPerformMock as jest.Mock<Promise<unknown>, []>,
+        );
+
+        innerPerformResultFixture = {
+          foo: 'bar',
+        };
+
+        (
+          innerPerformMock as jest.Mock<Promise<unknown>, []>
+        ).mockResolvedValueOnce(innerPerformResultFixture);
+
+        firstCallResult = await baseTask.perform();
+
+        secondCallResult = baseTask.result;
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call innerPerformMock', () => {
+        expect(innerPerformMock).toHaveBeenCalledTimes(1);
+        expect(innerPerformMock).toHaveBeenCalledWith();
+      });
+
+      it('should return a result on first call', () => {
+        expect(firstCallResult).toStrictEqual(innerPerformResultFixture);
+      });
+
+      it('should return a result on the second call', () => {
+        expect(secondCallResult).toStrictEqual(innerPerformResultFixture);
       });
     });
   });

--- a/packages/cuaktask/src/task/models/domain/BaseTask.ts
+++ b/packages/cuaktask/src/task/models/domain/BaseTask.ts
@@ -1,16 +1,28 @@
 import { NonThenableProperties } from '../../../common/models/NonThenableProperties';
 import { PromiseIfThenable } from '../../../common/models/PromiseIfThenable';
+import { PromiseLikeResult } from '../../../common/models/PromiseLikeResult';
 import { isPromiseLike } from '../../../utils/isPromiseLike';
 import { Task } from './Task';
 import { TaskStatus } from './TaskStatus';
 
 export abstract class BaseTask<TKind, TArgs extends unknown[], TReturn>
-  implements Task<TKind, TArgs, PromiseIfThenable<TReturn>>
+  implements Task<TKind, TArgs, TReturn>
 {
+  #innerResult:
+    | PromiseIfThenable<TReturn>
+    | PromiseLikeResult<TReturn>
+    | undefined;
   #innerStatus: TaskStatus;
 
   constructor(public readonly kind: TKind) {
     this.#innerStatus = TaskStatus.NotStarted;
+  }
+
+  public get result():
+    | PromiseIfThenable<TReturn>
+    | PromiseLikeResult<TReturn>
+    | undefined {
+    return this.#innerResult;
   }
 
   public get status(): TaskStatus {
@@ -20,36 +32,39 @@ export abstract class BaseTask<TKind, TArgs extends unknown[], TReturn>
   public perform(
     ...args: NonThenableProperties<TArgs>
   ): PromiseIfThenable<TReturn> {
-    this.#innerStatus = TaskStatus.InProgress;
+    if (this.#innerResult === undefined) {
+      this.#innerStatus = TaskStatus.InProgress;
 
-    try {
-      const innerResult: TReturn = this.innerPerform(...args);
+      try {
+        const innerResult: TReturn = this.innerPerform(...args);
 
-      let result: PromiseIfThenable<TReturn>;
+        if (isPromiseLike(innerResult)) {
+          this.#innerResult = this.#awaitAsyncResult(
+            innerResult,
+          ) as PromiseIfThenable<TReturn>;
+        } else {
+          this.#innerResult = innerResult as PromiseIfThenable<TReturn>;
+          this.#innerStatus = TaskStatus.Ended;
+        }
 
-      if (isPromiseLike(innerResult)) {
-        result = this.awaitAsyncResult(
-          innerResult,
-        ) as PromiseIfThenable<TReturn>;
-      } else {
-        result = innerResult as PromiseIfThenable<TReturn>;
-        this.#innerStatus = TaskStatus.Ended;
+        return this.#innerResult;
+      } catch (error: unknown) {
+        this.#innerStatus = TaskStatus.Error;
+
+        throw error;
       }
-
-      return result;
-    } catch (error: unknown) {
-      this.#innerStatus = TaskStatus.Error;
-
-      throw error;
+    } else {
+      throw new Error('A perform attemp has been already made');
     }
   }
 
-  private async awaitAsyncResult<TSyncReturn>(
+  async #awaitAsyncResult<TSyncReturn>(
     result: PromiseLike<TSyncReturn>,
   ): Promise<TSyncReturn> {
     try {
       const syncResult: TSyncReturn = await result;
 
+      this.#innerResult = syncResult as PromiseLikeResult<TReturn>;
       this.#innerStatus = TaskStatus.Ended;
 
       return syncResult;

--- a/packages/cuaktask/src/task/models/domain/ExpandedDependentTask.ts
+++ b/packages/cuaktask/src/task/models/domain/ExpandedDependentTask.ts
@@ -1,0 +1,15 @@
+import { ExpandedTask } from './ExpandedTask';
+
+export type ExpandedDependentTask<
+  TKind,
+  TDependencyKind,
+  TArgs extends unknown[],
+  TReturn,
+> = ExpandedTask<TKind, TArgs, TReturn> & {
+  readonly dependencies: ExpandedDependentTask<
+    TDependencyKind,
+    unknown,
+    unknown[],
+    unknown
+  >[];
+};

--- a/packages/cuaktask/src/task/models/domain/ExpandedTask.ts
+++ b/packages/cuaktask/src/task/models/domain/ExpandedTask.ts
@@ -1,0 +1,73 @@
+import { NonThenableProperties } from '../../../common/models/NonThenableProperties';
+import { PromiseIfThenable } from '../../../common/models/PromiseIfThenable';
+import { PromiseLikeResult } from '../../../common/models/PromiseLikeResult';
+import { TaskStatus } from './TaskStatus';
+
+/**
+ * Task model
+ */
+export type ExpandedTask<TKind, TArgs extends unknown[], TReturn> =
+  | NotStartedTask<TKind, TArgs, TReturn>
+  | InProgressTask<TKind, TArgs, TReturn>
+  | EndedTask<TKind, TArgs, TReturn>
+  | EndedWithErrorTask<TKind, TArgs>;
+
+export interface BaseTask<
+  TKind,
+  TResult,
+  TStatus extends TaskStatus,
+  TArgs extends unknown[],
+  TPerformResult,
+> {
+  /**
+   * Task kind.
+   */
+  readonly kind: TKind;
+  /**
+   * Task result
+   */
+  readonly result: TResult;
+  /**
+   * Task status.
+   */
+  readonly status: TStatus;
+
+  /**
+   * Performs the execution of a task.
+   * @param args task execution arguments.
+   * @returns task execution result.
+   */
+  perform(...args: NonThenableProperties<TArgs>): TPerformResult;
+}
+
+export type NotStartedTask<TKind, TArgs extends unknown[], TReturn> = BaseTask<
+  TKind,
+  never,
+  TaskStatus.NotStarted,
+  TArgs,
+  PromiseIfThenable<TReturn>
+>;
+
+export type InProgressTask<TKind, TArgs extends unknown[], TReturn> = BaseTask<
+  TKind,
+  PromiseIfThenable<TReturn>,
+  TaskStatus.InProgress,
+  TArgs,
+  never
+>;
+
+export type EndedTask<TKind, TArgs extends unknown[], TReturn> = BaseTask<
+  TKind,
+  PromiseLikeResult<TReturn>,
+  TaskStatus.Ended,
+  TArgs,
+  never
+>;
+
+export type EndedWithErrorTask<TKind, TArgs extends unknown[]> = BaseTask<
+  TKind,
+  never,
+  TaskStatus.Error,
+  TArgs,
+  never
+>;

--- a/packages/cuaktask/src/task/models/domain/Task.ts
+++ b/packages/cuaktask/src/task/models/domain/Task.ts
@@ -1,4 +1,6 @@
 import { NonThenableProperties } from '../../../common/models/NonThenableProperties';
+import { PromiseIfThenable } from '../../../common/models/PromiseIfThenable';
+import { PromiseLikeResult } from '../../../common/models/PromiseLikeResult';
 import { TaskStatus } from './TaskStatus';
 
 /**
@@ -9,6 +11,10 @@ export interface Task<TKind, TArgs extends unknown[], TReturn> {
    * Task kind.
    */
   readonly kind: TKind;
+  readonly result:
+    | PromiseIfThenable<TReturn>
+    | PromiseLikeResult<TReturn>
+    | undefined;
   /**
    * Task status.
    */
@@ -18,5 +24,5 @@ export interface Task<TKind, TArgs extends unknown[], TReturn> {
    * @param args task execution arguments.
    * @returns task execution result.
    */
-  perform(...args: NonThenableProperties<TArgs>): TReturn;
+  perform(...args: NonThenableProperties<TArgs>): PromiseIfThenable<TReturn>;
 }

--- a/packages/cuaktask/src/task/modules/DependentTaskBuildOperation.spec.ts
+++ b/packages/cuaktask/src/task/modules/DependentTaskBuildOperation.spec.ts
@@ -40,6 +40,11 @@ describe(DependentTaskBuilder.name, () => {
           dependencies: [],
           kind: taskKindFixture,
           perform: jest.fn(),
+          result: {
+            get: () => {
+              throw new Error();
+            },
+          },
           status: TaskStatus.NotStarted,
         };
 
@@ -100,6 +105,11 @@ describe(DependentTaskBuilder.name, () => {
         dependencies: [],
         kind: dependentTaskKindFixture,
         perform: jest.fn(),
+        result: {
+          get: () => {
+            throw new Error();
+          },
+        },
         status: TaskStatus.NotStarted,
       };
       taskKindFixture = 'some-kind';
@@ -107,6 +117,11 @@ describe(DependentTaskBuilder.name, () => {
         dependencies: [],
         kind: taskKindFixture,
         perform: jest.fn(),
+        result: {
+          get: () => {
+            throw new Error();
+          },
+        },
         status: TaskStatus.NotStarted,
       };
 

--- a/packages/cuaktask/src/task/modules/DependentTaskBuildOperation.spec.ts
+++ b/packages/cuaktask/src/task/modules/DependentTaskBuildOperation.spec.ts
@@ -1,11 +1,10 @@
 import { Builder } from '../../common/modules/Builder';
+import { DependentTaskMocks } from '../mocks/models/domain/DependentTaskMocks';
 import { DependentTask } from '../models/domain/DependentTask';
-import { TaskStatus } from '../models/domain/TaskStatus';
-import { DependentTaskBuilder } from './DependentTaskBuilder';
 import { DependentTaskBuildOperation } from './DependentTaskBuildOperation';
 import { TaskDependencyEngine } from './TaskDependencyEngine';
 
-describe(DependentTaskBuilder.name, () => {
+describe(DependentTaskBuildOperation.name, () => {
   let taskWithNoDependenciesBuilderMock: jest.Mocked<
     Builder<DependentTask<unknown>, [unknown]>
   >;
@@ -28,32 +27,20 @@ describe(DependentTaskBuilder.name, () => {
   });
 
   describe('.run()', () => {
-    describe('when called, with no dependencies', () => {
-      let taskKindFixture: string;
-      let taskFixture: DependentTask<string, unknown, unknown[], unknown>;
+    describe('when called, taskDependencyEngine.getDependencies returns and empty array', () => {
+      let taskFixture: DependentTask<unknown, unknown, unknown[], unknown>;
 
       let result: unknown;
 
       beforeAll(() => {
-        taskKindFixture = 'some-kind';
-        taskFixture = {
-          dependencies: [],
-          kind: taskKindFixture,
-          perform: jest.fn(),
-          result: {
-            get: () => {
-              throw new Error();
-            },
-          },
-          status: TaskStatus.NotStarted,
-        };
+        taskFixture = DependentTaskMocks.any;
 
         taskWithNoDependenciesBuilderMock.build.mockReturnValueOnce(
           taskFixture,
         );
         taskDependencyEngine.getDependencies.mockReturnValueOnce([]);
 
-        result = dependentTaskBuildOperation.run(taskKindFixture);
+        result = dependentTaskBuildOperation.run(taskFixture.kind);
       });
 
       afterAll(() => {
@@ -65,74 +52,49 @@ describe(DependentTaskBuilder.name, () => {
           1,
         );
         expect(taskWithNoDependenciesBuilderMock.build).toHaveBeenCalledWith(
-          taskKindFixture,
+          taskFixture.kind,
         );
       });
 
       it('should call taskDependencyEngine.getDependencies()', () => {
         expect(taskDependencyEngine.getDependencies).toHaveBeenCalledTimes(1);
         expect(taskDependencyEngine.getDependencies).toHaveBeenCalledWith(
-          taskKindFixture,
+          taskFixture.kind,
         );
       });
 
       it('should return a dependent task', () => {
-        const expected: DependentTask<string, unknown, unknown[], unknown> = {
-          ...taskFixture,
-        };
-
-        expect(result).toStrictEqual(expected);
+        expect(result).toStrictEqual(taskFixture);
       });
     });
   });
 
-  describe('when called, with dependencies', () => {
-    let dependentTaskKindFixture: string;
+  describe('when called, and taskDependencyEngine.getDependencies return dependencies', () => {
     let dependentTaskFixture: DependentTask<
-      string,
+      unknown,
       unknown,
       unknown[],
       unknown
     >;
-    let taskKindFixture: string;
-    let taskFixture: DependentTask<string, unknown, unknown[], unknown>;
+    let taskFixture: DependentTask<unknown, unknown, unknown[], unknown>;
 
     let result: unknown;
 
     beforeAll(() => {
-      dependentTaskKindFixture = 'dependent-kind';
       dependentTaskFixture = {
-        dependencies: [],
-        kind: dependentTaskKindFixture,
-        perform: jest.fn(),
-        result: {
-          get: () => {
-            throw new Error();
-          },
-        },
-        status: TaskStatus.NotStarted,
+        ...DependentTaskMocks.any,
+        kind: 'dependent-kind',
       };
-      taskKindFixture = 'some-kind';
-      taskFixture = {
-        dependencies: [],
-        kind: taskKindFixture,
-        perform: jest.fn(),
-        result: {
-          get: () => {
-            throw new Error();
-          },
-        },
-        status: TaskStatus.NotStarted,
-      };
+      taskFixture = DependentTaskMocks.any;
 
       taskWithNoDependenciesBuilderMock.build
         .mockReturnValueOnce(taskFixture)
         .mockReturnValueOnce(dependentTaskFixture);
       taskDependencyEngine.getDependencies
-        .mockReturnValueOnce([dependentTaskKindFixture])
+        .mockReturnValueOnce([dependentTaskFixture.kind])
         .mockReturnValueOnce([]);
 
-      result = dependentTaskBuildOperation.run(taskKindFixture);
+      result = dependentTaskBuildOperation.run(taskFixture.kind);
     });
 
     afterAll(() => {
@@ -143,11 +105,11 @@ describe(DependentTaskBuilder.name, () => {
       expect(taskWithNoDependenciesBuilderMock.build).toHaveBeenCalledTimes(2);
       expect(taskWithNoDependenciesBuilderMock.build).toHaveBeenNthCalledWith(
         1,
-        taskKindFixture,
+        taskFixture.kind,
       );
       expect(taskWithNoDependenciesBuilderMock.build).toHaveBeenNthCalledWith(
         2,
-        dependentTaskKindFixture,
+        dependentTaskFixture.kind,
       );
     });
 
@@ -155,16 +117,16 @@ describe(DependentTaskBuilder.name, () => {
       expect(taskDependencyEngine.getDependencies).toHaveBeenCalledTimes(2);
       expect(taskDependencyEngine.getDependencies).toHaveBeenNthCalledWith(
         1,
-        taskKindFixture,
+        taskFixture.kind,
       );
       expect(taskDependencyEngine.getDependencies).toHaveBeenNthCalledWith(
         2,
-        dependentTaskKindFixture,
+        dependentTaskFixture.kind,
       );
     });
 
     it('should return a dependent task', () => {
-      const expected: DependentTask<string, unknown, unknown[], unknown> = {
+      const expected: DependentTask<unknown, unknown, unknown[], unknown> = {
         ...taskFixture,
         dependencies: [dependentTaskFixture],
       };

--- a/packages/cuaktask/src/task/modules/DependentTaskBuilder.spec.ts
+++ b/packages/cuaktask/src/task/modules/DependentTaskBuilder.spec.ts
@@ -78,6 +78,11 @@ describe(DependentTaskBuilder.name, () => {
           dependencies: [],
           kind: taskKindFixture,
           perform: jest.fn(),
+          result: {
+            get: () => {
+              throw new Error();
+            },
+          },
           status: TaskStatus.NotStarted,
         };
 

--- a/packages/cuaktask/src/task/modules/DependentTaskBuilder.spec.ts
+++ b/packages/cuaktask/src/task/modules/DependentTaskBuilder.spec.ts
@@ -1,8 +1,8 @@
 jest.mock('./DependentTaskBuildOperation');
 
 import { Builder } from '../../common/modules/Builder';
+import { DependentTaskMocks } from '../mocks/models/domain/DependentTaskMocks';
 import { DependentTask } from '../models/domain/DependentTask';
-import { TaskStatus } from '../models/domain/TaskStatus';
 import { DependentTaskBuilder } from './DependentTaskBuilder';
 import { DependentTaskBuildOperation } from './DependentTaskBuildOperation';
 import { TaskDependencyEngine } from './TaskDependencyEngine';
@@ -67,24 +67,12 @@ describe(DependentTaskBuilder.name, () => {
   describe('.build()', () => {
     describe('when called', () => {
       let dependentTaskBuildOperationMock: jest.Mocked<DependentTaskBuildOperation>;
-      let taskKindFixture: string;
-      let taskFixture: DependentTask<string, unknown, unknown[], unknown>;
+      let taskFixture: DependentTask<unknown, unknown, unknown[], unknown>;
 
       let result: unknown;
 
       beforeAll(() => {
-        taskKindFixture = 'some-kind';
-        taskFixture = {
-          dependencies: [],
-          kind: taskKindFixture,
-          perform: jest.fn(),
-          result: {
-            get: () => {
-              throw new Error();
-            },
-          },
-          status: TaskStatus.NotStarted,
-        };
+        taskFixture = DependentTaskMocks.any;
 
         dependentTaskBuildOperationMock = {
           run: jest.fn().mockReturnValueOnce(taskFixture),
@@ -96,7 +84,7 @@ describe(DependentTaskBuilder.name, () => {
           DependentTaskBuildOperation as jest.Mock<DependentTaskBuildOperation>
         ).mockReturnValueOnce(dependentTaskBuildOperationMock);
 
-        result = dependentTaskBuilder.build(taskKindFixture);
+        result = dependentTaskBuilder.build(taskFixture.kind);
       });
 
       afterAll(() => {

--- a/packages/cuaktask/src/task/modules/DependentTaskRunner.spec.ts
+++ b/packages/cuaktask/src/task/modules/DependentTaskRunner.spec.ts
@@ -23,6 +23,11 @@ describe(DependentTaskRunner.name, () => {
           dependencies: [],
           kind: 'sample-task-kind',
           perform: jest.fn().mockReturnValue(dependentTaskResultFixture),
+          result: {
+            get: () => {
+              throw new Error();
+            },
+          },
           status: TaskStatus.NotStarted,
         };
       });
@@ -49,7 +54,7 @@ describe(DependentTaskRunner.name, () => {
       });
     });
 
-    describe('having a asyncronous task with asyncronous dependencies', () => {
+    describe('having an asyncronous task with asyncronous dependencies', () => {
       let dependencyTaskMock: jest.Mocked<
         DependentTask<string, unknown, unknown[], unknown>
       >;
@@ -67,12 +72,22 @@ describe(DependentTaskRunner.name, () => {
           dependencies: [],
           kind: 'sample-dependency-task-kind',
           perform: jest.fn().mockResolvedValue(dependencyTaskResultFixture),
+          result: {
+            get: () => {
+              throw new Error();
+            },
+          },
           status: TaskStatus.NotStarted,
         };
         dependentTaskMock = {
           dependencies: [dependencyTaskMock],
           kind: 'sample-task-kind',
           perform: jest.fn().mockResolvedValue(dependentTaskResultFixture),
+          result: {
+            get: () => {
+              throw new Error();
+            },
+          },
           status: TaskStatus.NotStarted,
         };
       });
@@ -116,15 +131,15 @@ describe(DependentTaskRunner.name, () => {
           );
         });
 
-        it('should return the task result', () => {
-          expect(result).toStrictEqual(
-            Promise.resolve(dependentTaskResultFixture),
+        it('should return the task result', async () => {
+          await expect(result).resolves.toStrictEqual(
+            dependentTaskResultFixture,
           );
         });
       });
     });
 
-    describe('having a asyncronous task with syncronous dependencies', () => {
+    describe('having an asyncronous task with syncronous dependencies', () => {
       let dependencyTaskMock: jest.Mocked<
         DependentTask<string, unknown, unknown[], unknown>
       >;
@@ -142,12 +157,22 @@ describe(DependentTaskRunner.name, () => {
           dependencies: [],
           kind: 'sample-dependency-task-kind',
           perform: jest.fn().mockReturnValue(dependencyTaskResultFixture),
+          result: {
+            get: () => {
+              throw new Error();
+            },
+          },
           status: TaskStatus.NotStarted,
         };
         dependentTaskMock = {
           dependencies: [dependencyTaskMock],
           kind: 'sample-task-kind',
           perform: jest.fn().mockResolvedValue(dependentTaskResultFixture),
+          result: {
+            get: () => {
+              throw new Error();
+            },
+          },
           status: TaskStatus.NotStarted,
         };
       });
@@ -191,9 +216,9 @@ describe(DependentTaskRunner.name, () => {
           );
         });
 
-        it('should return the task result', () => {
-          expect(result).toStrictEqual(
-            Promise.resolve(dependentTaskResultFixture),
+        it('should return the task result', async () => {
+          await expect(result).resolves.toStrictEqual(
+            dependentTaskResultFixture,
           );
         });
       });
@@ -217,12 +242,22 @@ describe(DependentTaskRunner.name, () => {
           dependencies: [],
           kind: 'sample-dependency-task-kind',
           perform: jest.fn().mockResolvedValue(dependencyTaskResultFixture),
+          result: {
+            get: () => {
+              throw new Error();
+            },
+          },
           status: TaskStatus.NotStarted,
         };
         dependentTaskMock = {
           dependencies: [dependencyTaskMock],
           kind: 'sample-task-kind',
           perform: jest.fn().mockReturnValue(dependentTaskResultFixture),
+          result: {
+            get: () => {
+              throw new Error();
+            },
+          },
           status: TaskStatus.NotStarted,
         };
       });
@@ -266,9 +301,9 @@ describe(DependentTaskRunner.name, () => {
           );
         });
 
-        it('should return the task result', () => {
-          expect(result).toStrictEqual(
-            Promise.resolve(dependentTaskResultFixture),
+        it('should return the task result', async () => {
+          await expect(result).resolves.toStrictEqual(
+            dependentTaskResultFixture,
           );
         });
       });
@@ -292,12 +327,22 @@ describe(DependentTaskRunner.name, () => {
           dependencies: [],
           kind: 'sample-dependency-task-kind',
           perform: jest.fn().mockReturnValue(dependencyTaskResultFixture),
+          result: {
+            get: () => {
+              throw new Error();
+            },
+          },
           status: TaskStatus.NotStarted,
         };
         dependentTaskMock = {
           dependencies: [dependencyTaskMock],
           kind: 'sample-task-kind',
           perform: jest.fn().mockReturnValue(dependentTaskResultFixture),
+          result: {
+            get: () => {
+              throw new Error();
+            },
+          },
           status: TaskStatus.NotStarted,
         };
       });

--- a/packages/cuaktask/src/task/modules/DependentTaskRunner.spec.ts
+++ b/packages/cuaktask/src/task/modules/DependentTaskRunner.spec.ts
@@ -1,5 +1,5 @@
+import { DependentTaskMocks } from '../mocks/models/domain/DependentTaskMocks';
 import { DependentTask } from '../models/domain/DependentTask';
-import { TaskStatus } from '../models/domain/TaskStatus';
 import { DependentTaskRunner } from './DependentTaskRunner';
 
 describe(DependentTaskRunner.name, () => {
@@ -10,9 +10,9 @@ describe(DependentTaskRunner.name, () => {
   });
 
   describe('.run()', () => {
-    describe('having a task with no dependencies', () => {
+    describe('having a task with status different than NotStarted', () => {
       let dependentTaskMock: jest.Mocked<
-        DependentTask<string, unknown, unknown[], unknown>
+        DependentTask<unknown, unknown, unknown[], unknown>
       >;
       let dependentTaskResultFixture: unknown;
 
@@ -20,16 +20,45 @@ describe(DependentTaskRunner.name, () => {
         dependentTaskResultFixture = 'sample-result';
 
         dependentTaskMock = {
-          dependencies: [],
-          kind: 'sample-task-kind',
-          perform: jest.fn().mockReturnValue(dependentTaskResultFixture),
-          result: {
-            get: () => {
-              throw new Error();
-            },
-          },
-          status: TaskStatus.NotStarted,
+          ...DependentTaskMocks.withStatusEnded,
+          result: dependentTaskResultFixture,
         };
+      });
+
+      describe('when called', () => {
+        let result: unknown;
+
+        beforeAll(() => {
+          result = dependentTaskRunner.run(dependentTaskMock);
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should not call dependentTaskMock.perform()', () => {
+          expect(dependentTaskMock.perform).not.toHaveBeenCalled();
+        });
+
+        it('should return the task result', () => {
+          expect(result).toBe(dependentTaskResultFixture);
+        });
+      });
+    });
+
+    describe('having a task with status NotStarted and no dependencies', () => {
+      let dependentTaskMock: jest.Mocked<
+        DependentTask<unknown, unknown, unknown[], unknown>
+      >;
+      let dependentTaskResultFixture: unknown;
+
+      beforeAll(() => {
+        dependentTaskResultFixture = 'sample-result';
+
+        dependentTaskMock =
+          DependentTaskMocks.withDependenciesEmptyAndStatusNotStarted;
+
+        dependentTaskMock.perform.mockReturnValue(dependentTaskResultFixture);
       });
 
       describe('when called', () => {
@@ -54,13 +83,13 @@ describe(DependentTaskRunner.name, () => {
       });
     });
 
-    describe('having an asyncronous task with asyncronous dependencies', () => {
+    describe('having an asyncronous task with with status NotStarted and asyncronous dependencies', () => {
       let dependencyTaskMock: jest.Mocked<
-        DependentTask<string, unknown, unknown[], unknown>
+        DependentTask<unknown, unknown, unknown[], unknown>
       >;
       let dependencyTaskResultFixture: unknown;
       let dependentTaskMock: jest.Mocked<
-        DependentTask<string, unknown, unknown[], unknown>
+        DependentTask<unknown, unknown, unknown[], unknown>
       >;
       let dependentTaskResultFixture: unknown;
 
@@ -69,27 +98,21 @@ describe(DependentTaskRunner.name, () => {
         dependentTaskResultFixture = 'sample-result';
 
         dependencyTaskMock = {
-          dependencies: [],
+          ...DependentTaskMocks.withDependenciesEmptyAndStatusNotStarted,
           kind: 'sample-dependency-task-kind',
-          perform: jest.fn().mockResolvedValue(dependencyTaskResultFixture),
-          result: {
-            get: () => {
-              throw new Error();
-            },
-          },
-          status: TaskStatus.NotStarted,
         };
+        (
+          dependencyTaskMock.perform as jest.Mock<Promise<unknown>>
+        ).mockResolvedValue(dependencyTaskResultFixture);
+
         dependentTaskMock = {
+          ...DependentTaskMocks.withDependenciesEmptyAndStatusNotStarted,
           dependencies: [dependencyTaskMock],
           kind: 'sample-task-kind',
-          perform: jest.fn().mockResolvedValue(dependentTaskResultFixture),
-          result: {
-            get: () => {
-              throw new Error();
-            },
-          },
-          status: TaskStatus.NotStarted,
         };
+        (
+          dependentTaskMock.perform as jest.Mock<Promise<unknown>>
+        ).mockResolvedValue(dependentTaskResultFixture);
       });
 
       describe('when called', () => {
@@ -139,7 +162,7 @@ describe(DependentTaskRunner.name, () => {
       });
     });
 
-    describe('having an asyncronous task with syncronous dependencies', () => {
+    describe('having an asyncronous task with status NotStarted and syncronous dependencies', () => {
       let dependencyTaskMock: jest.Mocked<
         DependentTask<string, unknown, unknown[], unknown>
       >;
@@ -154,27 +177,19 @@ describe(DependentTaskRunner.name, () => {
         dependentTaskResultFixture = 'sample-result';
 
         dependencyTaskMock = {
-          dependencies: [],
+          ...DependentTaskMocks.withDependenciesEmptyAndStatusNotStarted,
           kind: 'sample-dependency-task-kind',
-          perform: jest.fn().mockReturnValue(dependencyTaskResultFixture),
-          result: {
-            get: () => {
-              throw new Error();
-            },
-          },
-          status: TaskStatus.NotStarted,
         };
+        dependencyTaskMock.perform.mockReturnValue(dependencyTaskResultFixture);
+
         dependentTaskMock = {
+          ...DependentTaskMocks.withDependenciesEmptyAndStatusNotStarted,
           dependencies: [dependencyTaskMock],
           kind: 'sample-task-kind',
-          perform: jest.fn().mockResolvedValue(dependentTaskResultFixture),
-          result: {
-            get: () => {
-              throw new Error();
-            },
-          },
-          status: TaskStatus.NotStarted,
         };
+        (
+          dependentTaskMock.perform as jest.Mock<Promise<unknown>>
+        ).mockResolvedValue(dependentTaskResultFixture);
       });
 
       describe('when called', () => {
@@ -224,7 +239,7 @@ describe(DependentTaskRunner.name, () => {
       });
     });
 
-    describe('having a syncronous task with asyncronous dependencies', () => {
+    describe('having a syncronous task with status NotStarted and asyncronous dependencies', () => {
       let dependencyTaskMock: jest.Mocked<
         DependentTask<string, unknown, unknown[], unknown>
       >;
@@ -239,27 +254,19 @@ describe(DependentTaskRunner.name, () => {
         dependentTaskResultFixture = 'sample-result';
 
         dependencyTaskMock = {
-          dependencies: [],
+          ...DependentTaskMocks.withDependenciesEmptyAndStatusNotStarted,
           kind: 'sample-dependency-task-kind',
-          perform: jest.fn().mockResolvedValue(dependencyTaskResultFixture),
-          result: {
-            get: () => {
-              throw new Error();
-            },
-          },
-          status: TaskStatus.NotStarted,
         };
+        (
+          dependencyTaskMock.perform as jest.Mock<Promise<unknown>>
+        ).mockResolvedValue(dependencyTaskResultFixture);
+
         dependentTaskMock = {
+          ...DependentTaskMocks.withDependenciesEmptyAndStatusNotStarted,
           dependencies: [dependencyTaskMock],
           kind: 'sample-task-kind',
-          perform: jest.fn().mockReturnValue(dependentTaskResultFixture),
-          result: {
-            get: () => {
-              throw new Error();
-            },
-          },
-          status: TaskStatus.NotStarted,
         };
+        dependentTaskMock.perform.mockReturnValue(dependentTaskResultFixture);
       });
 
       describe('when called', () => {
@@ -309,7 +316,7 @@ describe(DependentTaskRunner.name, () => {
       });
     });
 
-    describe('having a syncronous task with syncronous dependencies', () => {
+    describe('having a syncronous task with status NotStarted and syncronous dependencies', () => {
       let dependencyTaskMock: jest.Mocked<
         DependentTask<string, unknown, unknown[], unknown>
       >;
@@ -324,27 +331,17 @@ describe(DependentTaskRunner.name, () => {
         dependentTaskResultFixture = 'sample-result';
 
         dependencyTaskMock = {
-          dependencies: [],
+          ...DependentTaskMocks.withDependenciesEmptyAndStatusNotStarted,
           kind: 'sample-dependency-task-kind',
-          perform: jest.fn().mockReturnValue(dependencyTaskResultFixture),
-          result: {
-            get: () => {
-              throw new Error();
-            },
-          },
-          status: TaskStatus.NotStarted,
         };
+        dependencyTaskMock.perform.mockReturnValue(dependencyTaskResultFixture);
+
         dependentTaskMock = {
+          ...DependentTaskMocks.withDependenciesEmptyAndStatusNotStarted,
           dependencies: [dependencyTaskMock],
           kind: 'sample-task-kind',
-          perform: jest.fn().mockReturnValue(dependentTaskResultFixture),
-          result: {
-            get: () => {
-              throw new Error();
-            },
-          },
-          status: TaskStatus.NotStarted,
         };
+        dependentTaskMock.perform.mockReturnValue(dependentTaskResultFixture);
       });
 
       describe('when called', () => {

--- a/packages/cuaktask/src/task/modules/DependentTaskRunner.ts
+++ b/packages/cuaktask/src/task/modules/DependentTaskRunner.ts
@@ -20,6 +20,22 @@ export class DependentTaskRunner {
     return this.#innerRun(dependenTask);
   }
 
+  #castToExpandedDependentTask<
+    TKind,
+    TDependencyKind,
+    TArgs extends unknown[],
+    TReturn,
+  >(
+    dependenTask: DependentTask<TKind, TDependencyKind, TArgs, TReturn>,
+  ): ExpandedDependentTask<TKind, TDependencyKind, TArgs, TReturn> {
+    return dependenTask as ExpandedDependentTask<
+      TKind,
+      TDependencyKind,
+      TArgs,
+      TReturn
+    >;
+  }
+
   #innerRun<TKind, TDependencyKind, TArgs extends unknown[], TReturn>(
     dependenTask: DependentTask<TKind, TDependencyKind, TArgs, TReturn>,
   ): MayBePromise<TReturn> {
@@ -32,22 +48,12 @@ export class DependentTaskRunner {
 
       if (dependenciesRunResults.some(isPromiseLike)) {
         result = this.#innerRunDependenciesAsync(
-          dependenTask as ExpandedDependentTask<
-            TKind,
-            TDependencyKind,
-            TArgs,
-            TReturn
-          >,
+          this.#castToExpandedDependentTask(dependenTask),
           dependenciesRunResults,
         ) as MayBePromise<TReturn>;
       } else {
         result = this.#innerRunTask(
-          dependenTask as ExpandedDependentTask<
-            TKind,
-            TDependencyKind,
-            TArgs,
-            TReturn
-          >,
+          this.#castToExpandedDependentTask(dependenTask),
           dependenciesRunResults as NonThenableProperties<TArgs>,
         );
       }

--- a/packages/cuaktask/src/task/modules/SafeDependentTaskBuildOperation.spec.ts
+++ b/packages/cuaktask/src/task/modules/SafeDependentTaskBuildOperation.spec.ts
@@ -55,6 +55,11 @@ describe(DependentTaskBuilder.name, () => {
           dependencies: [],
           kind: dependentTaskKindFixture,
           perform: jest.fn(),
+          result: {
+            get: () => {
+              throw new Error();
+            },
+          },
           status: TaskStatus.NotStarted,
         };
         taskKindFixture = 'some-kind';
@@ -62,6 +67,11 @@ describe(DependentTaskBuilder.name, () => {
           dependencies: [],
           kind: taskKindFixture,
           perform: jest.fn(),
+          result: {
+            get: () => {
+              throw new Error();
+            },
+          },
           status: TaskStatus.NotStarted,
         };
 

--- a/packages/cuaktask/src/task/modules/SafeDependentTaskBuildOperation.spec.ts
+++ b/packages/cuaktask/src/task/modules/SafeDependentTaskBuildOperation.spec.ts
@@ -1,12 +1,11 @@
 import { Builder } from '../../common/modules/Builder';
 import { SetLike } from '../../common/modules/SetLike';
+import { DependentTaskMocks } from '../mocks/models/domain/DependentTaskMocks';
 import { DependentTask } from '../models/domain/DependentTask';
-import { TaskStatus } from '../models/domain/TaskStatus';
-import { DependentTaskBuilder } from './DependentTaskBuilder';
 import { SafeDependentTaskBuildOperation } from './SafeDependentTaskBuildOperation';
 import { TaskDependencyEngine } from './TaskDependencyEngine';
 
-describe(DependentTaskBuilder.name, () => {
+describe(SafeDependentTaskBuildOperation.name, () => {
   let taskWithNoDependenciesBuilderMock: jest.Mocked<
     Builder<DependentTask<unknown>, [unknown]>
   >;
@@ -37,42 +36,24 @@ describe(DependentTaskBuilder.name, () => {
 
   describe('.build()', () => {
     describe('when called, with no circular dependencies', () => {
-      let dependentTaskKindFixture: string;
       let dependentTaskFixture: DependentTask<
         string,
         unknown,
         unknown[],
         unknown
       >;
-      let taskKindFixture: string;
       let taskFixture: DependentTask<string, unknown, unknown[], unknown>;
 
       let result: unknown;
 
       beforeAll(() => {
-        dependentTaskKindFixture = 'dependent-kind';
         dependentTaskFixture = {
-          dependencies: [],
-          kind: dependentTaskKindFixture,
-          perform: jest.fn(),
-          result: {
-            get: () => {
-              throw new Error();
-            },
-          },
-          status: TaskStatus.NotStarted,
+          ...DependentTaskMocks.any,
+          kind: 'dependent-kind',
         };
-        taskKindFixture = 'some-kind';
         taskFixture = {
-          dependencies: [],
-          kind: taskKindFixture,
-          perform: jest.fn(),
-          result: {
-            get: () => {
-              throw new Error();
-            },
-          },
-          status: TaskStatus.NotStarted,
+          ...DependentTaskMocks.any,
+          kind: 'some-kind',
         };
 
         taskDependenciesKindSet.has
@@ -83,10 +64,10 @@ describe(DependentTaskBuilder.name, () => {
           .mockReturnValueOnce(taskFixture)
           .mockReturnValueOnce(dependentTaskFixture);
         taskDependencyEngine.getDependencies
-          .mockReturnValueOnce([dependentTaskKindFixture])
+          .mockReturnValueOnce([dependentTaskFixture.kind])
           .mockReturnValueOnce([]);
 
-        result = safeDependentTaskBuildOperation.run(taskKindFixture);
+        result = safeDependentTaskBuildOperation.run(taskFixture.kind);
       });
 
       afterAll(() => {
@@ -97,11 +78,11 @@ describe(DependentTaskBuilder.name, () => {
         expect(taskDependenciesKindSet.has).toHaveBeenCalledTimes(2);
         expect(taskDependenciesKindSet.has).toHaveBeenNthCalledWith(
           1,
-          taskKindFixture,
+          taskFixture.kind,
         );
         expect(taskDependenciesKindSet.has).toHaveBeenNthCalledWith(
           2,
-          dependentTaskKindFixture,
+          dependentTaskFixture.kind,
         );
       });
 
@@ -111,11 +92,11 @@ describe(DependentTaskBuilder.name, () => {
         );
         expect(taskWithNoDependenciesBuilderMock.build).toHaveBeenNthCalledWith(
           1,
-          taskKindFixture,
+          taskFixture.kind,
         );
         expect(taskWithNoDependenciesBuilderMock.build).toHaveBeenNthCalledWith(
           2,
-          dependentTaskKindFixture,
+          dependentTaskFixture.kind,
         );
       });
 
@@ -123,11 +104,11 @@ describe(DependentTaskBuilder.name, () => {
         expect(taskDependencyEngine.getDependencies).toHaveBeenCalledTimes(2);
         expect(taskDependencyEngine.getDependencies).toHaveBeenNthCalledWith(
           1,
-          taskKindFixture,
+          taskFixture.kind,
         );
         expect(taskDependencyEngine.getDependencies).toHaveBeenNthCalledWith(
           2,
-          dependentTaskKindFixture,
+          dependentTaskFixture.kind,
         );
       });
 

--- a/packages/cuaktask/src/task/modules/SafeDependentTaskBuilder.spec.ts
+++ b/packages/cuaktask/src/task/modules/SafeDependentTaskBuilder.spec.ts
@@ -2,8 +2,8 @@ jest.mock('./SafeDependentTaskBuildOperation');
 
 import { Builder } from '../../common/modules/Builder';
 import { SetLike } from '../../common/modules/SetLike';
+import { DependentTaskMocks } from '../mocks/models/domain/DependentTaskMocks';
 import { DependentTask } from '../models/domain/DependentTask';
-import { TaskStatus } from '../models/domain/TaskStatus';
 import { SafeDependentTaskBuilder } from './SafeDependentTaskBuilder';
 import { SafeDependentTaskBuildOperation } from './SafeDependentTaskBuildOperation';
 import { TaskDependencyEngine } from './TaskDependencyEngine';
@@ -77,24 +77,12 @@ describe(SafeDependentTaskBuilder.name, () => {
     describe('when called', () => {
       let safeDependentTaskBuildOperationMock: jest.Mocked<SafeDependentTaskBuildOperation>;
       let taskDependenciesKindSetMock: SetLike<unknown>;
-      let taskKindFixture: string;
-      let taskFixture: DependentTask<string, unknown, unknown[], unknown>;
+      let taskFixture: DependentTask<unknown, unknown, unknown[], unknown>;
 
       let result: unknown;
 
       beforeAll(() => {
-        taskKindFixture = 'some-kind';
-        taskFixture = {
-          dependencies: [],
-          kind: taskKindFixture,
-          perform: jest.fn(),
-          result: {
-            get: () => {
-              throw new Error();
-            },
-          },
-          status: TaskStatus.NotStarted,
-        };
+        taskFixture = DependentTaskMocks.any;
 
         taskDependenciesKindSetMock = {
           add: jest.fn(),
@@ -117,7 +105,7 @@ describe(SafeDependentTaskBuilder.name, () => {
           SafeDependentTaskBuildOperation as jest.Mock<SafeDependentTaskBuildOperation>
         ).mockReturnValueOnce(safeDependentTaskBuildOperationMock);
 
-        result = safeDependentTaskBuilder.build(taskKindFixture);
+        result = safeDependentTaskBuilder.build(taskFixture.kind);
       });
 
       afterAll(() => {

--- a/packages/cuaktask/src/task/modules/SafeDependentTaskBuilder.spec.ts
+++ b/packages/cuaktask/src/task/modules/SafeDependentTaskBuilder.spec.ts
@@ -88,6 +88,11 @@ describe(SafeDependentTaskBuilder.name, () => {
           dependencies: [],
           kind: taskKindFixture,
           perform: jest.fn(),
+          result: {
+            get: () => {
+              throw new Error();
+            },
+          },
           status: TaskStatus.NotStarted,
         };
 

--- a/packages/iocuak/src/container/services/cuaktask/ContainerInstanceServiceImplementation.spec.ts
+++ b/packages/iocuak/src/container/services/cuaktask/ContainerInstanceServiceImplementation.spec.ts
@@ -64,6 +64,11 @@ describe(ContainerInstanceServiceImplementation.name, () => {
         dependencies: [],
         kind: taskKindFixture,
         perform: jest.fn(),
+        result: {
+          get: () => {
+            throw new Error();
+          },
+        },
         status: TaskStatus.NotStarted,
       };
 

--- a/packages/iocuak/src/container/services/cuaktask/ContainerInstanceServiceImplementation.ts
+++ b/packages/iocuak/src/container/services/cuaktask/ContainerInstanceServiceImplementation.ts
@@ -38,9 +38,8 @@ export class ContainerInstanceServiceImplementation
       type: TaskKindType.createInstance,
     };
 
-    const createInstanceTask: CreateInstanceTask = this.#taskBuilder.build(
-      taskKind,
-    ) as CreateInstanceTask;
+    const createInstanceTask: CreateInstanceTask<TInstance> =
+      this.#taskBuilder.build(taskKind) as CreateInstanceTask<TInstance>;
 
     this.#containerRequestService.end(requestId);
 


### PR DESCRIPTION
### Changed
- Updated `BaseTask` to throw an error if `perform` is called more than once.
- Updated `BaseTask` with a `result` property.