### PR TITLE
Release @cuaklabs/cuaktask@0.2.0

### DIFF
--- a/packages/cuaktask/.npmignore
+++ b/packages/cuaktask/.npmignore
@@ -1,2 +1,4 @@
+**/*.spec.js
+**/*.spec.js.map
 **/*.ts
 !**/*.d.ts

--- a/packages/cuaktask/CHANGELOG.md
+++ b/packages/cuaktask/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
-## [UNRELEASED]
+## 0.2.0 - 2022-04-19
 
 ### Added
 - Added `TaskDependencyKindGraph`.

--- a/packages/cuaktask/package.json
+++ b/packages/cuaktask/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuaklabs/cuaktask",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Minimal abstract task manager",
   "main": "lib/index.js",
   "repository": {

--- a/packages/iocuak/.npmignore
+++ b/packages/iocuak/.npmignore
@@ -1,2 +1,4 @@
+**/*.spec.js
+**/*.spec.js.map
 **/*.ts
 !**/*.d.ts

--- a/packages/porygon-typeorm/.npmignore
+++ b/packages/porygon-typeorm/.npmignore
@@ -1,2 +1,4 @@
+**/*.spec.js
+**/*.spec.js.map
 **/*.ts
 !**/*.d.ts

--- a/packages/porygon/.npmignore
+++ b/packages/porygon/.npmignore
@@ -1,2 +1,4 @@
+**/*.spec.js
+**/*.spec.js.map
 **/*.ts
 !**/*.d.ts


### PR DESCRIPTION
## 0.2.0 - 2022-04-19

### Added
- Added `TaskDependencyKindGraph`.
- Added `TaskDependencyKindGraphNode`.

### Changed
- Updated index to expose `isPromiseLike`
- **[BC]** Updated `TaskDependencyEngine` to return a task kind dependency graph.
- **[BC]** Updated `TaskDependencyBuilder` to no longer receive a set builder.
- **[BC]** Updated `BaseTask` to throw an error if `perform` is called more than once.
- Updated `BaseTask` with a `result` property.