### PR TITLE
Add container module class metadata api

### DIFF
--- a/packages/cuaktask/CHANGELOG.md
+++ b/packages/cuaktask/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
+## [UNRELEASED]
+
+
+
+
 ## 0.2.0 - 2022-04-19
 
 ### Added

--- a/packages/iocuak/CHANGELOG.md
+++ b/packages/iocuak/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Updated `Container.get` to create instance of newable unbinded types.
+- Updated `ContainerModuleMetadata` to allow class metadata
 
 ### Fixed
 - Fixed `Container.unbind` to remove unbound singleton services

--- a/packages/iocuak/src/container/modules/api/ContainerApi.int.spec.ts
+++ b/packages/iocuak/src/container/modules/api/ContainerApi.int.spec.ts
@@ -7,7 +7,6 @@ import { inject } from '../../../metadata/decorators/inject';
 import { injectable } from '../../../metadata/decorators/injectable';
 import { ContainerModuleBindingServiceApi } from '../../services/api/ContainerModuleBindingServiceApi';
 import { ContainerApi } from './ContainerApi';
-import { ContainerModuleApi } from './ContainerModuleApi';
 
 describe(ContainerApi.name, () => {
   describe('.bind', () => {
@@ -380,10 +379,7 @@ describe(ContainerApi.name, () => {
       let dependentServiceIdFixture: ServiceId;
       let valueFixture: unknown;
 
-      let containerModuleMetadataApi: ContainerModuleMetadataApi<
-        ContainerModuleApi,
-        [unknown]
-      >;
+      let containerModuleMetadataApi: ContainerModuleMetadataApi<[unknown]>;
 
       beforeAll(() => {
         serviceIdFixture = 'service';

--- a/packages/iocuak/src/container/services/api/ContainerServiceApiImplementation.spec.ts
+++ b/packages/iocuak/src/container/services/api/ContainerServiceApiImplementation.spec.ts
@@ -1,5 +1,5 @@
 jest.mock(
-  '../../../containerModuleTask/utils/convertToContainerModuleMetadata',
+  '../../../containerModuleTask/utils/api/convertToContainerModuleMetadata',
 );
 jest.mock('../../utils/bind');
 jest.mock('../../utils/bindToValue');
@@ -9,7 +9,7 @@ import { Newable } from '../../../common/models/domain/Newable';
 import { ServiceId } from '../../../common/models/domain/ServiceId';
 import { ContainerModuleMetadataApi } from '../../../containerModuleTask/models/api/ContainerModuleMetadataApi';
 import { ContainerModuleMetadata } from '../../../containerModuleTask/models/domain/ContainerModuleMetadata';
-import { convertToContainerModuleMetadata } from '../../../containerModuleTask/utils/convertToContainerModuleMetadata';
+import { convertToContainerModuleMetadata } from '../../../containerModuleTask/utils/api/convertToContainerModuleMetadata';
 import { BindingApi } from '../../../metadata/models/api/BindingApi';
 import { BindingTypeApi } from '../../../metadata/models/api/BindingTypeApi';
 import { Binding } from '../../../metadata/models/domain/Binding';

--- a/packages/iocuak/src/container/services/api/ContainerServiceApiImplementation.ts
+++ b/packages/iocuak/src/container/services/api/ContainerServiceApiImplementation.ts
@@ -2,7 +2,7 @@ import { Newable } from '../../../common/models/domain/Newable';
 import { ServiceId } from '../../../common/models/domain/ServiceId';
 import { ContainerModuleMetadataApi } from '../../../containerModuleTask/models/api/ContainerModuleMetadataApi';
 import { ContainerModuleMetadata } from '../../../containerModuleTask/models/domain/ContainerModuleMetadata';
-import { convertToContainerModuleMetadata } from '../../../containerModuleTask/utils/convertToContainerModuleMetadata';
+import { convertToContainerModuleMetadata } from '../../../containerModuleTask/utils/api/convertToContainerModuleMetadata';
 import { BindingApi } from '../../../metadata/models/api/BindingApi';
 import { Binding } from '../../../metadata/models/domain/Binding';
 import { convertBindingToBindingApi } from '../../../metadata/utils/api/convertBindingToBindingApi';

--- a/packages/iocuak/src/containerModuleTask/mocks/models/api/ContainerModuleMetadataApiMocks.ts
+++ b/packages/iocuak/src/containerModuleTask/mocks/models/api/ContainerModuleMetadataApiMocks.ts
@@ -1,7 +1,28 @@
+import { ContainerModuleClassMetadataApi } from '../../../models/api/ContainerModuleClassMetadataApi';
+import { ContainerModuleFactoryMetadataApi } from '../../../models/api/ContainerModuleFactoryMetadataApi';
 import { ContainerModuleMetadataApi } from '../../../models/api/ContainerModuleMetadataApi';
 
 export class ContainerModuleMetadataApiMocks {
   public static get any(): jest.Mocked<ContainerModuleMetadataApi> {
+    const fixture: jest.Mocked<ContainerModuleMetadataApi> = {
+      factory: jest.fn(),
+      imports: [],
+      injects: [],
+    };
+
+    return fixture;
+  }
+
+  public static get anyContainerModuleClassMetadataApi(): jest.Mocked<ContainerModuleClassMetadataApi> {
+    const fixture: jest.Mocked<ContainerModuleClassMetadataApi> = {
+      imports: [],
+      module: jest.fn(),
+    };
+
+    return fixture;
+  }
+
+  public static get anyContainerModuleFactoryMetadataApi(): jest.Mocked<ContainerModuleFactoryMetadataApi> {
     const fixture: jest.Mocked<ContainerModuleMetadataApi> = {
       factory: jest.fn(),
       imports: [],

--- a/packages/iocuak/src/containerModuleTask/mocks/models/domain/ContainerModuleMetadataMocks.ts
+++ b/packages/iocuak/src/containerModuleTask/mocks/models/domain/ContainerModuleMetadataMocks.ts
@@ -48,7 +48,8 @@ export class ContainerModuleMetadataMocks {
   public static get withTypeClazz(): ContainerModuleClassMetadata {
     const fixture: ContainerModuleMetadata = {
       imports: [],
-      module: ContainerModuleMetadataMocks.#classFixture,
+      loader: () => undefined,
+      moduleType: ContainerModuleMetadataMocks.#classFixture,
       type: ContainerModuleMetadataType.clazz,
     };
 

--- a/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleClassMetadataApi.ts
+++ b/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleClassMetadataApi.ts
@@ -1,0 +1,8 @@
+import { Newable } from '../../../common/models/domain/Newable';
+import { ContainerModuleApi } from '../../../container/modules/api/ContainerModuleApi';
+import { ContainerModuleMetadataBaseApi } from './ContainerModuleMetadataBaseApi';
+
+export interface ContainerModuleClassMetadataApi
+  extends ContainerModuleMetadataBaseApi {
+  module: Newable<ContainerModuleApi>;
+}

--- a/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleFactoryMetadataApi.ts
+++ b/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleFactoryMetadataApi.ts
@@ -1,0 +1,10 @@
+import { ServiceId } from '../../../common/models/domain/ServiceId';
+import { ContainerModuleApi } from '../../../container/modules/api/ContainerModuleApi';
+import { ContainerModuleMetadataBaseApi } from './ContainerModuleMetadataBaseApi';
+
+export interface ContainerModuleFactoryMetadataApi<
+  TArgs extends unknown[] = unknown[],
+> extends ContainerModuleMetadataBaseApi {
+  factory: (...args: TArgs) => ContainerModuleApi | Promise<ContainerModuleApi>;
+  injects: ServiceId[];
+}

--- a/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleMetadataApi.ts
+++ b/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleMetadataApi.ts
@@ -1,4 +1,6 @@
+import { ContainerModuleClassMetadataApi } from './ContainerModuleClassMetadataApi';
 import { ContainerModuleFactoryMetadataApi } from './ContainerModuleFactoryMetadataApi';
 
 export type ContainerModuleMetadataApi<TArgs extends unknown[] = unknown[]> =
-  ContainerModuleFactoryMetadataApi<TArgs>;
+  | ContainerModuleFactoryMetadataApi<TArgs>
+  | ContainerModuleClassMetadataApi;

--- a/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleMetadataApi.ts
+++ b/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleMetadataApi.ts
@@ -1,11 +1,11 @@
 import { ServiceId } from '../../../common/models/domain/ServiceId';
 import { ContainerModuleApi } from '../../../container/modules/api/ContainerModuleApi';
+import { ContainerModuleMetadataBaseApi } from './ContainerModuleMetadataBaseApi';
 
 export interface ContainerModuleMetadataApi<
   TModule extends ContainerModuleApi = ContainerModuleApi,
   TArgs extends unknown[] = unknown[],
-> {
+> extends ContainerModuleMetadataBaseApi {
   factory: (...args: TArgs) => TModule | Promise<TModule>;
-  imports: ContainerModuleMetadataApi<ContainerModuleApi>[];
   injects: ServiceId[];
 }

--- a/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleMetadataApi.ts
+++ b/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleMetadataApi.ts
@@ -1,11 +1,4 @@
-import { ServiceId } from '../../../common/models/domain/ServiceId';
-import { ContainerModuleApi } from '../../../container/modules/api/ContainerModuleApi';
-import { ContainerModuleMetadataBaseApi } from './ContainerModuleMetadataBaseApi';
+import { ContainerModuleFactoryMetadataApi } from './ContainerModuleFactoryMetadataApi';
 
-export interface ContainerModuleMetadataApi<
-  TModule extends ContainerModuleApi = ContainerModuleApi,
-  TArgs extends unknown[] = unknown[],
-> extends ContainerModuleMetadataBaseApi {
-  factory: (...args: TArgs) => TModule | Promise<TModule>;
-  injects: ServiceId[];
-}
+export type ContainerModuleMetadataApi<TArgs extends unknown[] = unknown[]> =
+  ContainerModuleFactoryMetadataApi<TArgs>;

--- a/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleMetadataBaseApi.ts
+++ b/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleMetadataBaseApi.ts
@@ -1,0 +1,6 @@
+import { ContainerModuleApi } from '../../../container/modules/api/ContainerModuleApi';
+import { ContainerModuleMetadataApi } from './ContainerModuleMetadataApi';
+
+export interface ContainerModuleMetadataBaseApi {
+  imports: ContainerModuleMetadataApi<ContainerModuleApi>[];
+}

--- a/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleMetadataBaseApi.ts
+++ b/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleMetadataBaseApi.ts
@@ -1,6 +1,5 @@
-import { ContainerModuleApi } from '../../../container/modules/api/ContainerModuleApi';
 import { ContainerModuleMetadataApi } from './ContainerModuleMetadataApi';
 
 export interface ContainerModuleMetadataBaseApi {
-  imports: ContainerModuleMetadataApi<ContainerModuleApi>[];
+  imports: ContainerModuleMetadataApi[];
 }

--- a/packages/iocuak/src/containerModuleTask/models/cuaktast/ContainerModuleLoadFromMetadataTask.ts
+++ b/packages/iocuak/src/containerModuleTask/models/cuaktast/ContainerModuleLoadFromMetadataTask.ts
@@ -57,8 +57,21 @@ export class ContainerModuleLoadFromMetadataTask extends cuaktask.BaseDependentT
   #loadFromContainerModuleClassMetadata(
     metadata: ContainerModuleClassMetadata,
   ): ContainerModule {
-    const containerModule: ContainerModule =
-      this.#containerInstanceService.create(metadata.module);
+    const containerModuleFromMetadata: unknown =
+      this.#containerInstanceService.create(metadata.moduleType);
+
+    const containerModule: ContainerModule = {
+      load: (
+        containerBindingService: ContainerBindingService,
+        metadataService: MetadataService,
+      ): void => {
+        metadata.loader(
+          containerModuleFromMetadata,
+          containerBindingService,
+          metadataService,
+        );
+      },
+    };
 
     return containerModule;
   }

--- a/packages/iocuak/src/containerModuleTask/models/domain/ContainerModuleClassMetadata.ts
+++ b/packages/iocuak/src/containerModuleTask/models/domain/ContainerModuleClassMetadata.ts
@@ -1,9 +1,15 @@
 import { Newable } from '../../../common/models/domain/Newable';
-import { ContainerModule } from '../../../container/modules/domain/ContainerModule';
+import { ContainerBindingService } from '../../../container/services/domain/ContainerBindingService';
+import { MetadataService } from '../../../metadata/services/domain/MetadataService';
 import { ContainerModuleMetadataBase } from './ContainerModuleMetadataBase';
 import { ContainerModuleMetadataType } from './ContainerModuleMetadataType';
 
-export interface ContainerModuleClassMetadata
+export interface ContainerModuleClassMetadata<TModule = unknown>
   extends ContainerModuleMetadataBase<ContainerModuleMetadataType.clazz> {
-  module: Newable<ContainerModule>;
+  loader: (
+    module: TModule,
+    containerBindingService: ContainerBindingService,
+    metadataService: MetadataService,
+  ) => void;
+  moduleType: Newable<TModule>;
 }

--- a/packages/iocuak/src/containerModuleTask/modules/ContainerModuleTaskBuilderWithNoDependencies.ts
+++ b/packages/iocuak/src/containerModuleTask/modules/ContainerModuleTaskBuilderWithNoDependencies.ts
@@ -8,7 +8,7 @@ import { ContainerModuleLoadFromMetadataTask } from '../models/cuaktast/Containe
 import { ContainerModuleCreateInstancesTaskKind } from '../models/domain/ContainerModuleCreateInstancesTaskKind';
 import { ContainerModuleLoadFromMetadataTaskKind } from '../models/domain/ContainerModuleLoadFromMetadataTaskKind';
 import { ContainerModuleTaskKindType } from '../models/domain/ContainerModuleTaskKindType';
-import { isContainerModuleTaskKind } from '../utils/isContainerModuleTaskKind';
+import { isContainerModuleTaskKind } from '../utils/domain/isContainerModuleTaskKind';
 
 export class ContainerModuleTaskBuilderWithNoDependencies {
   readonly #containerBindingService: ContainerBindingService;

--- a/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModule.spec.ts
+++ b/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModule.spec.ts
@@ -1,15 +1,15 @@
-jest.mock('../../container/utils/bind');
-jest.mock('../../container/utils/bindToValue');
+jest.mock('../../../container/utils/bind');
+jest.mock('../../../container/utils/bindToValue');
 
-import { Newable } from '../../common/models/domain/Newable';
-import { ServiceId } from '../../common/models/domain/ServiceId';
-import { ContainerModuleApi } from '../../container/modules/api/ContainerModuleApi';
-import { ContainerModule } from '../../container/modules/domain/ContainerModule';
-import { ContainerModuleBindingServiceApi } from '../../container/services/api/ContainerModuleBindingServiceApi';
-import { ContainerBindingService } from '../../container/services/domain/ContainerBindingService';
-import { bind } from '../../container/utils/bind';
-import { bindToValue } from '../../container/utils/bindToValue';
-import { MetadataService } from '../../metadata/services/domain/MetadataService';
+import { Newable } from '../../../common/models/domain/Newable';
+import { ServiceId } from '../../../common/models/domain/ServiceId';
+import { ContainerModuleApi } from '../../../container/modules/api/ContainerModuleApi';
+import { ContainerModule } from '../../../container/modules/domain/ContainerModule';
+import { ContainerModuleBindingServiceApi } from '../../../container/services/api/ContainerModuleBindingServiceApi';
+import { ContainerBindingService } from '../../../container/services/domain/ContainerBindingService';
+import { bind } from '../../../container/utils/bind';
+import { bindToValue } from '../../../container/utils/bindToValue';
+import { MetadataService } from '../../../metadata/services/domain/MetadataService';
 import { convertToContainerModule } from './convertToContainerModule';
 
 describe(convertToContainerModule.name, () => {

--- a/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModule.ts
+++ b/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModule.ts
@@ -1,12 +1,12 @@
-import { Newable } from '../../common/models/domain/Newable';
-import { ServiceId } from '../../common/models/domain/ServiceId';
-import { ContainerModuleApi } from '../../container/modules/api/ContainerModuleApi';
-import { ContainerModule } from '../../container/modules/domain/ContainerModule';
-import { ContainerModuleBindingServiceApi } from '../../container/services/api/ContainerModuleBindingServiceApi';
-import { ContainerBindingService } from '../../container/services/domain/ContainerBindingService';
-import { bind } from '../../container/utils/bind';
-import { bindToValue } from '../../container/utils/bindToValue';
-import { MetadataService } from '../../metadata/services/domain/MetadataService';
+import { Newable } from '../../../common/models/domain/Newable';
+import { ServiceId } from '../../../common/models/domain/ServiceId';
+import { ContainerModuleApi } from '../../../container/modules/api/ContainerModuleApi';
+import { ContainerModule } from '../../../container/modules/domain/ContainerModule';
+import { ContainerModuleBindingServiceApi } from '../../../container/services/api/ContainerModuleBindingServiceApi';
+import { ContainerBindingService } from '../../../container/services/domain/ContainerBindingService';
+import { bind } from '../../../container/utils/bind';
+import { bindToValue } from '../../../container/utils/bindToValue';
+import { MetadataService } from '../../../metadata/services/domain/MetadataService';
 
 export function convertToContainerModule(
   containerModuleApi: ContainerModuleApi,

--- a/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleAsync.spec.ts
+++ b/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleAsync.spec.ts
@@ -1,6 +1,6 @@
 jest.mock('./convertToContainerModule');
 
-import { ContainerModuleApi } from '../../container/modules/api/ContainerModuleApi';
+import { ContainerModuleApi } from '../../../container/modules/api/ContainerModuleApi';
 import { convertToContainerModule } from './convertToContainerModule';
 import { convertToContainerModuleAsync } from './convertToContainerModuleAsync';
 

--- a/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleAsync.ts
+++ b/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleAsync.ts
@@ -1,5 +1,5 @@
-import { ContainerModuleApi } from '../../container/modules/api/ContainerModuleApi';
-import { ContainerModule } from '../../container/modules/domain/ContainerModule';
+import { ContainerModuleApi } from '../../../container/modules/api/ContainerModuleApi';
+import { ContainerModule } from '../../../container/modules/domain/ContainerModule';
 import { convertToContainerModule } from './convertToContainerModule';
 
 export async function convertToContainerModuleAsync(

--- a/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleMetadata.spec.ts
+++ b/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleMetadata.spec.ts
@@ -1,13 +1,13 @@
 jest.mock('./convertToContainerModule');
 jest.mock('./convertToContainerModuleAsync');
 
-import { ContainerModuleApi } from '../../container/modules/api/ContainerModuleApi';
-import { ContainerModule } from '../../container/modules/domain/ContainerModule';
-import { ContainerModuleMetadataApiMocks } from '../mocks/models/api/ContainerModuleMetadataApiMocks';
-import { ContainerModuleMetadataApi } from '../models/api/ContainerModuleMetadataApi';
-import { ContainerModuleFactoryMetadata } from '../models/domain/ContainerModuleFactoryMetadata';
-import { ContainerModuleMetadata } from '../models/domain/ContainerModuleMetadata';
-import { ContainerModuleMetadataType } from '../models/domain/ContainerModuleMetadataType';
+import { ContainerModuleApi } from '../../../container/modules/api/ContainerModuleApi';
+import { ContainerModule } from '../../../container/modules/domain/ContainerModule';
+import { ContainerModuleMetadataApiMocks } from '../../mocks/models/api/ContainerModuleMetadataApiMocks';
+import { ContainerModuleMetadataApi } from '../../models/api/ContainerModuleMetadataApi';
+import { ContainerModuleFactoryMetadata } from '../../models/domain/ContainerModuleFactoryMetadata';
+import { ContainerModuleMetadata } from '../../models/domain/ContainerModuleMetadata';
+import { ContainerModuleMetadataType } from '../../models/domain/ContainerModuleMetadataType';
 import { convertToContainerModule } from './convertToContainerModule';
 import { convertToContainerModuleAsync } from './convertToContainerModuleAsync';
 import { convertToContainerModuleMetadata } from './convertToContainerModuleMetadata';

--- a/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleMetadata.spec.ts
+++ b/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleMetadata.spec.ts
@@ -3,8 +3,12 @@ jest.mock('./convertToContainerModuleAsync');
 
 import { ContainerModuleApi } from '../../../container/modules/api/ContainerModuleApi';
 import { ContainerModule } from '../../../container/modules/domain/ContainerModule';
+import { ContainerBindingService } from '../../../container/services/domain/ContainerBindingService';
+import { MetadataService } from '../../../metadata/services/domain/MetadataService';
 import { ContainerModuleMetadataApiMocks } from '../../mocks/models/api/ContainerModuleMetadataApiMocks';
-import { ContainerModuleMetadataApi } from '../../models/api/ContainerModuleMetadataApi';
+import { ContainerModuleClassMetadataApi } from '../../models/api/ContainerModuleClassMetadataApi';
+import { ContainerModuleFactoryMetadataApi } from '../../models/api/ContainerModuleFactoryMetadataApi';
+import { ContainerModuleClassMetadata } from '../../models/domain/ContainerModuleClassMetadata';
 import { ContainerModuleFactoryMetadata } from '../../models/domain/ContainerModuleFactoryMetadata';
 import { ContainerModuleMetadata } from '../../models/domain/ContainerModuleMetadata';
 import { ContainerModuleMetadataType } from '../../models/domain/ContainerModuleMetadataType';
@@ -13,16 +17,109 @@ import { convertToContainerModuleAsync } from './convertToContainerModuleAsync';
 import { convertToContainerModuleMetadata } from './convertToContainerModuleMetadata';
 
 describe(convertToContainerModuleMetadata.name, () => {
-  describe('having a ContainerModuleMetadataApiMocks with imports', () => {
-    let containerModuleMetadataApiImportMock: jest.Mocked<ContainerModuleMetadataApi>;
-    let containerModuleMetadataApiMock: jest.Mocked<ContainerModuleMetadataApi>;
+  describe('having a ContainerModuleClassMetadataApi', () => {
+    let containerModuleClassMetadataApiMock: jest.Mocked<ContainerModuleClassMetadataApi>;
 
     beforeAll(() => {
-      containerModuleMetadataApiImportMock =
-        ContainerModuleMetadataApiMocks.any;
-      containerModuleMetadataApiMock = {
-        ...ContainerModuleMetadataApiMocks.any,
-        imports: [containerModuleMetadataApiImportMock],
+      containerModuleClassMetadataApiMock =
+        ContainerModuleMetadataApiMocks.anyContainerModuleClassMetadataApi;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+      let containerModuleMetadata: ContainerModuleClassMetadata;
+
+      beforeAll(() => {
+        result = convertToContainerModuleMetadata(
+          containerModuleClassMetadataApiMock,
+        );
+
+        containerModuleMetadata = result as ContainerModuleClassMetadata;
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should return a ContainerModuleMetadata', () => {
+        const expected: ContainerModuleClassMetadata = {
+          imports: expect.any(Array) as ContainerModuleMetadata[],
+          loader: expect.any(
+            Function,
+          ) as ContainerModuleClassMetadata['loader'],
+          moduleType: containerModuleClassMetadataApiMock.module,
+          type: ContainerModuleMetadataType.clazz,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+
+      describe('when loader is called', () => {
+        let containerModuleMock: jest.Mocked<ContainerModule>;
+        let containerModuleApiFixture: ContainerModuleApi;
+        let containerBindingServiceFixture: ContainerBindingService;
+        let metadataServiceFixture: MetadataService;
+
+        beforeAll(() => {
+          containerModuleMock = {
+            load: jest.fn(),
+          };
+
+          containerModuleApiFixture = {
+            _tag: Symbol('ContainerModuleApi'),
+          } as Partial<ContainerModuleApi> as ContainerModuleApi;
+
+          containerBindingServiceFixture = {
+            _tag: Symbol('ContainerBindingService'),
+          } as Partial<ContainerBindingService> as ContainerBindingService;
+
+          metadataServiceFixture = {
+            _tag: Symbol('MetadataService'),
+          } as Partial<MetadataService> as MetadataService;
+
+          (
+            convertToContainerModule as jest.Mock<ContainerModule>
+          ).mockReturnValueOnce(containerModuleMock);
+
+          containerModuleMetadata.loader(
+            containerModuleApiFixture,
+            containerBindingServiceFixture,
+            metadataServiceFixture,
+          );
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call convertToContainerModule()', () => {
+          expect(convertToContainerModule).toHaveBeenCalledTimes(1);
+          expect(convertToContainerModule).toHaveBeenCalledWith(
+            containerModuleApiFixture,
+          );
+        });
+
+        it('should call containerModule.load()', () => {
+          expect(containerModuleMock.load).toHaveBeenCalledTimes(1);
+          expect(containerModuleMock.load).toHaveBeenCalledWith(
+            containerBindingServiceFixture,
+            metadataServiceFixture,
+          );
+        });
+      });
+    });
+  });
+
+  describe('having a ContainerModuleClassMetadataApi with imports', () => {
+    let dependencyContainerModuleClassMetadataApiMock: jest.Mocked<ContainerModuleClassMetadataApi>;
+    let containerModuleClassMetadataApiMock: jest.Mocked<ContainerModuleClassMetadataApi>;
+
+    beforeAll(() => {
+      dependencyContainerModuleClassMetadataApiMock =
+        ContainerModuleMetadataApiMocks.anyContainerModuleClassMetadataApi;
+      containerModuleClassMetadataApiMock = {
+        ...ContainerModuleMetadataApiMocks.anyContainerModuleClassMetadataApi,
+        imports: [dependencyContainerModuleClassMetadataApiMock],
       };
     });
 
@@ -31,7 +128,202 @@ describe(convertToContainerModuleMetadata.name, () => {
 
       beforeAll(() => {
         result = convertToContainerModuleMetadata(
-          containerModuleMetadataApiMock,
+          containerModuleClassMetadataApiMock,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should return a ContainerModuleMetadata', () => {
+        const expected: ContainerModuleClassMetadata = {
+          imports: [
+            {
+              imports: expect.any(Array) as ContainerModuleMetadata[],
+              loader: expect.any(
+                Function,
+              ) as ContainerModuleClassMetadata['loader'],
+              moduleType: dependencyContainerModuleClassMetadataApiMock.module,
+              type: ContainerModuleMetadataType.clazz,
+            },
+          ],
+          loader: expect.any(
+            Function,
+          ) as ContainerModuleClassMetadata['loader'],
+          moduleType: containerModuleClassMetadataApiMock.module,
+          type: ContainerModuleMetadataType.clazz,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having a ContainerModuleFactoryMetadataApi', () => {
+    let containerModuleFactoryMetadataApiMock: jest.Mocked<ContainerModuleFactoryMetadataApi>;
+
+    beforeAll(() => {
+      containerModuleFactoryMetadataApiMock =
+        ContainerModuleMetadataApiMocks.anyContainerModuleFactoryMetadataApi;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+      let containerModuleMetadata: ContainerModuleFactoryMetadata;
+
+      beforeAll(() => {
+        result = convertToContainerModuleMetadata(
+          containerModuleFactoryMetadataApiMock,
+        );
+
+        containerModuleMetadata = result as ContainerModuleFactoryMetadata;
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should return a ContainerModuleMetadata', () => {
+        const expected: ContainerModuleMetadata = {
+          factory: expect.any(
+            Function,
+          ) as ContainerModuleFactoryMetadata['factory'],
+          imports: expect.any(Array) as ContainerModuleMetadata[],
+          injects: [...containerModuleFactoryMetadataApiMock.injects],
+          type: ContainerModuleMetadataType.factory,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+
+      describe('when factory is called and containerModuleMetadataApi.factory returns a promise', () => {
+        let containerModuleApiFixture: ContainerModuleApi;
+        let containerModuleFixture: ContainerModule;
+        let argumentsFixture: unknown[];
+        let result: unknown;
+
+        beforeAll(async () => {
+          containerModuleApiFixture = {
+            _tag: 'containerModuleApi',
+          } as unknown as ContainerModuleApi;
+
+          containerModuleFixture = {
+            _tag: 'containerModule',
+          } as unknown as ContainerModule;
+
+          (
+            convertToContainerModuleAsync as jest.Mock<Promise<ContainerModule>>
+          ).mockResolvedValueOnce(containerModuleFixture);
+
+          containerModuleFactoryMetadataApiMock.factory.mockResolvedValueOnce(
+            containerModuleApiFixture,
+          );
+
+          argumentsFixture = [Symbol()];
+
+          result = await containerModuleMetadata.factory(...argumentsFixture);
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call containerModuleMetadataApi.factory()', () => {
+          expect(
+            containerModuleFactoryMetadataApiMock.factory,
+          ).toHaveBeenCalledTimes(1);
+          expect(
+            containerModuleFactoryMetadataApiMock.factory,
+          ).toHaveBeenCalledWith(...argumentsFixture);
+        });
+
+        it('should call convertToContainerModuleAsync()', () => {
+          expect(convertToContainerModuleAsync).toHaveBeenCalledTimes(1);
+          expect(convertToContainerModuleAsync).toHaveBeenCalledWith(
+            Promise.resolve(containerModuleApiFixture),
+          );
+        });
+
+        it('should return a ContainerModule', () => {
+          expect(result).toBe(containerModuleFixture);
+        });
+      });
+
+      describe('when factory is called and containerModuleMetadataApi.factory returns a non promise', () => {
+        let containerModuleApiFixture: ContainerModuleApi;
+        let containerModuleFixture: ContainerModule;
+        let argumentsFixture: unknown[];
+        let result: unknown;
+
+        beforeAll(() => {
+          containerModuleApiFixture = {
+            _tag: 'containerModuleApi',
+          } as unknown as ContainerModuleApi;
+
+          containerModuleFixture = {
+            _tag: 'containerModule',
+          } as unknown as ContainerModule;
+
+          (
+            convertToContainerModule as jest.Mock<ContainerModule>
+          ).mockReturnValueOnce(containerModuleFixture);
+
+          containerModuleFactoryMetadataApiMock.factory.mockReturnValueOnce(
+            containerModuleApiFixture,
+          );
+
+          argumentsFixture = [Symbol()];
+
+          result = containerModuleMetadata.factory(...argumentsFixture);
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call containerModuleMetadataApi.factory()', () => {
+          expect(
+            containerModuleFactoryMetadataApiMock.factory,
+          ).toHaveBeenCalledTimes(1);
+          expect(
+            containerModuleFactoryMetadataApiMock.factory,
+          ).toHaveBeenCalledWith(...argumentsFixture);
+        });
+
+        it('should call convertToContainerModule()', () => {
+          expect(convertToContainerModule).toHaveBeenCalledTimes(1);
+          expect(convertToContainerModule).toHaveBeenCalledWith(
+            containerModuleApiFixture,
+          );
+        });
+
+        it('should return a ContainerModule', () => {
+          expect(result).toBe(containerModuleFixture);
+        });
+      });
+    });
+  });
+
+  describe('having a ContainerModuleFactoryMetadataApi with imports', () => {
+    let dependencyContainerModuleFactoryMetadataApiMock: jest.Mocked<ContainerModuleFactoryMetadataApi>;
+    let containerModuleFactoryMetadataApiMock: jest.Mocked<ContainerModuleFactoryMetadataApi>;
+
+    beforeAll(() => {
+      dependencyContainerModuleFactoryMetadataApiMock =
+        ContainerModuleMetadataApiMocks.anyContainerModuleFactoryMetadataApi;
+      containerModuleFactoryMetadataApiMock = {
+        ...ContainerModuleMetadataApiMocks.anyContainerModuleFactoryMetadataApi,
+        imports: [dependencyContainerModuleFactoryMetadataApiMock],
+      };
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = convertToContainerModuleMetadata(
+          containerModuleFactoryMetadataApiMock,
         );
       });
 
@@ -50,148 +342,17 @@ describe(convertToContainerModuleMetadata.name, () => {
                 Function,
               ) as ContainerModuleFactoryMetadata['factory'],
               imports: expect.any(Array) as ContainerModuleMetadata[],
-              injects: [...containerModuleMetadataApiImportMock.injects],
+              injects: [
+                ...dependencyContainerModuleFactoryMetadataApiMock.injects,
+              ],
               type: ContainerModuleMetadataType.factory,
             },
           ],
-          injects: [...containerModuleMetadataApiMock.injects],
+          injects: [...containerModuleFactoryMetadataApiMock.injects],
           type: ContainerModuleMetadataType.factory,
         };
 
         expect(result).toStrictEqual(expected);
-      });
-    });
-  });
-
-  describe('when called', () => {
-    let containerModuleMetadataApiMock: jest.Mocked<ContainerModuleMetadataApi>;
-    let result: unknown;
-    let containerModuleMetadata: ContainerModuleFactoryMetadata;
-
-    beforeAll(() => {
-      containerModuleMetadataApiMock = ContainerModuleMetadataApiMocks.any;
-
-      result = convertToContainerModuleMetadata(containerModuleMetadataApiMock);
-
-      containerModuleMetadata = result as ContainerModuleFactoryMetadata;
-    });
-
-    afterAll(() => {
-      jest.clearAllMocks();
-    });
-
-    it('should return a ContainerModuleMetadata', () => {
-      const expected: ContainerModuleMetadata = {
-        factory: expect.any(
-          Function,
-        ) as ContainerModuleFactoryMetadata['factory'],
-        imports: expect.any(Array) as ContainerModuleMetadata[],
-        injects: [...containerModuleMetadataApiMock.injects],
-        type: ContainerModuleMetadataType.factory,
-      };
-
-      expect(result).toStrictEqual(expected);
-    });
-
-    describe('when factory is called and containerModuleMetadataApi.factory returns a promise', () => {
-      let containerModuleApiFixture: ContainerModuleApi;
-      let containerModuleFixture: ContainerModule;
-      let argumentsFixture: unknown[];
-      let result: unknown;
-
-      beforeAll(async () => {
-        containerModuleApiFixture = {
-          _tag: 'containerModuleApi',
-        } as unknown as ContainerModuleApi;
-
-        containerModuleFixture = {
-          _tag: 'containerModule',
-        } as unknown as ContainerModule;
-
-        (
-          convertToContainerModuleAsync as jest.Mock<Promise<ContainerModule>>
-        ).mockResolvedValueOnce(containerModuleFixture);
-
-        containerModuleMetadataApiMock.factory.mockResolvedValueOnce(
-          containerModuleApiFixture,
-        );
-
-        argumentsFixture = [Symbol()];
-
-        result = await containerModuleMetadata.factory(...argumentsFixture);
-      });
-
-      afterAll(() => {
-        jest.clearAllMocks();
-      });
-
-      it('should call containerModuleMetadataApi.factory()', () => {
-        expect(containerModuleMetadataApiMock.factory).toHaveBeenCalledTimes(1);
-        expect(containerModuleMetadataApiMock.factory).toHaveBeenCalledWith(
-          ...argumentsFixture,
-        );
-      });
-
-      it('should call convertToContainerModuleAsync()', () => {
-        expect(convertToContainerModuleAsync).toHaveBeenCalledTimes(1);
-        expect(convertToContainerModuleAsync).toHaveBeenCalledWith(
-          Promise.resolve(containerModuleApiFixture),
-        );
-      });
-
-      it('should return a ContainerModule', () => {
-        expect(result).toBe(containerModuleFixture);
-      });
-    });
-
-    describe('when factory is called and containerModuleMetadataApi.factory returns a non promise', () => {
-      let containerModuleApiFixture: ContainerModuleApi;
-      let containerModuleFixture: ContainerModule;
-      let argumentsFixture: unknown[];
-      let result: unknown;
-
-      beforeAll(() => {
-        containerModuleApiFixture = {
-          _tag: 'containerModuleApi',
-        } as unknown as ContainerModuleApi;
-
-        containerModuleFixture = {
-          _tag: 'containerModule',
-        } as unknown as ContainerModule;
-
-        (
-          convertToContainerModule as jest.Mock<ContainerModule>
-        ).mockReturnValueOnce(containerModuleFixture);
-
-        containerModuleMetadataApiMock.factory.mockReturnValueOnce(
-          containerModuleApiFixture,
-        );
-
-        argumentsFixture = [Symbol()];
-
-        result = containerModuleMetadata.factory(...argumentsFixture);
-      });
-
-      afterAll(() => {
-        jest.clearAllMocks();
-      });
-
-      it('should call containerModuleMetadataApi.factory()', () => {
-        expect(containerModuleMetadataApiMock.factory).toHaveBeenCalledTimes(1);
-        expect(containerModuleMetadataApiMock.factory).toHaveBeenCalledWith(
-          ...argumentsFixture,
-        );
-      });
-
-      it('should call convertToContainerModule()', () => {
-        expect(convertToContainerModule).toHaveBeenCalledTimes(1);
-        expect(convertToContainerModule).toHaveBeenCalledWith(
-          containerModuleApiFixture,
-        );
-      });
-
-      it('should return a ContainerModule', () => {
-        expect(result).toBe(containerModuleFixture);
       });
     });
   });

--- a/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleMetadata.ts
+++ b/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleMetadata.ts
@@ -1,10 +1,10 @@
 import { isPromiseLike } from '@cuaklabs/cuaktask';
 
-import { ContainerModuleApi } from '../../container/modules/api/ContainerModuleApi';
-import { ContainerModule } from '../../container/modules/domain/ContainerModule';
-import { ContainerModuleMetadataApi } from '../models/api/ContainerModuleMetadataApi';
-import { ContainerModuleMetadata } from '../models/domain/ContainerModuleMetadata';
-import { ContainerModuleMetadataType } from '../models/domain/ContainerModuleMetadataType';
+import { ContainerModuleApi } from '../../../container/modules/api/ContainerModuleApi';
+import { ContainerModule } from '../../../container/modules/domain/ContainerModule';
+import { ContainerModuleMetadataApi } from '../../models/api/ContainerModuleMetadataApi';
+import { ContainerModuleMetadata } from '../../models/domain/ContainerModuleMetadata';
+import { ContainerModuleMetadataType } from '../../models/domain/ContainerModuleMetadataType';
 import { convertToContainerModule } from './convertToContainerModule';
 import { convertToContainerModuleAsync } from './convertToContainerModuleAsync';
 

--- a/packages/iocuak/src/containerModuleTask/utils/api/isContainerModuleClassMetadataApi.ts
+++ b/packages/iocuak/src/containerModuleTask/utils/api/isContainerModuleClassMetadataApi.ts
@@ -1,0 +1,10 @@
+import { ContainerModuleClassMetadataApi } from '../../models/api/ContainerModuleClassMetadataApi';
+import { ContainerModuleMetadataApi } from '../../models/api/ContainerModuleMetadataApi';
+
+export function isContainerModuleClassMetadataApi<TArgs extends unknown[]>(
+  value: ContainerModuleMetadataApi<TArgs>,
+): value is ContainerModuleClassMetadataApi {
+  return (
+    typeof (value as ContainerModuleClassMetadataApi).module === 'function'
+  );
+}

--- a/packages/iocuak/src/containerModuleTask/utils/convertToContainerModuleMetadata.ts
+++ b/packages/iocuak/src/containerModuleTask/utils/convertToContainerModuleMetadata.ts
@@ -9,10 +9,7 @@ import { convertToContainerModule } from './convertToContainerModule';
 import { convertToContainerModuleAsync } from './convertToContainerModuleAsync';
 
 export function convertToContainerModuleMetadata<TArgs extends unknown[]>(
-  containerModuleMetadataApi: ContainerModuleMetadataApi<
-    ContainerModuleApi,
-    TArgs
-  >,
+  containerModuleMetadataApi: ContainerModuleMetadataApi<TArgs>,
 ): ContainerModuleMetadata<TArgs> {
   const containerModuleMetadata: ContainerModuleMetadata<TArgs> = {
     factory: convertToContainerModuleMetadataFactory(

--- a/packages/iocuak/src/containerModuleTask/utils/domain/isContainerModuleTaskKind.spec.ts
+++ b/packages/iocuak/src/containerModuleTask/utils/domain/isContainerModuleTaskKind.spec.ts
@@ -1,4 +1,4 @@
-import { ContainerModuleTaskKindType } from '../models/domain/ContainerModuleTaskKindType';
+import { ContainerModuleTaskKindType } from '../../models/domain/ContainerModuleTaskKindType';
 import { isContainerModuleTaskKind } from './isContainerModuleTaskKind';
 
 describe(isContainerModuleTaskKind.name, () => {

--- a/packages/iocuak/src/containerModuleTask/utils/domain/isContainerModuleTaskKind.ts
+++ b/packages/iocuak/src/containerModuleTask/utils/domain/isContainerModuleTaskKind.ts
@@ -1,5 +1,5 @@
-import { ContainerModuleTaskKind } from '../models/domain/ContainerModuleTaskKind';
-import { ContainerModuleTaskKindType } from '../models/domain/ContainerModuleTaskKindType';
+import { ContainerModuleTaskKind } from '../../models/domain/ContainerModuleTaskKind';
+import { ContainerModuleTaskKindType } from '../../models/domain/ContainerModuleTaskKindType';
 
 export function isContainerModuleTaskKind(
   value: unknown,


### PR DESCRIPTION
### Added
- Added `ContainerModuleClassMetadataApi`.

### Changed
- Updated `ContainerModuleClassMetadata` with loader.
- Updated `ContainerModuleMetadataApi` to include `ContainerModuleClassMetadataApi`.
- Updated `ContainerModuleLoadFromMetadataTask` to handle `ContainerModuleClassMetadata`
- Updated `convertToContainerModuleMetadata` to handle `ContainerModuleClassMetadataApi`