### PR TITLE
Update container metadata api with optional properties

### DIFF
--- a/packages/iocuak/CHANGELOG.md
+++ b/packages/iocuak/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Updated `Container.get` to create instance of newable unbinded types.
 - Updated `ContainerModuleMetadata` to allow class metadata
+- Updated `ContainerModuleMetadata.imports` to be optional.
+- Updated `ContainerModuleMetadata.injects` to be optional.
 
 ### Fixed
 - Fixed `Container.unbind` to remove unbound singleton services

--- a/packages/iocuak/src/containerModuleTask/mocks/models/api/ContainerModuleMetadataApiMocks.ts
+++ b/packages/iocuak/src/containerModuleTask/mocks/models/api/ContainerModuleMetadataApiMocks.ts
@@ -6,7 +6,6 @@ export class ContainerModuleMetadataApiMocks {
   public static get any(): jest.Mocked<ContainerModuleMetadataApi> {
     const fixture: jest.Mocked<ContainerModuleMetadataApi> = {
       factory: jest.fn(),
-      imports: [],
     };
 
     return fixture;
@@ -14,7 +13,6 @@ export class ContainerModuleMetadataApiMocks {
 
   public static get anyContainerModuleClassMetadataApi(): jest.Mocked<ContainerModuleClassMetadataApi> {
     const fixture: jest.Mocked<ContainerModuleClassMetadataApi> = {
-      imports: [],
       module: jest.fn(),
     };
 
@@ -24,7 +22,6 @@ export class ContainerModuleMetadataApiMocks {
   public static get anyContainerModuleFactoryMetadataApi(): jest.Mocked<ContainerModuleFactoryMetadataApi> {
     const fixture: jest.Mocked<ContainerModuleMetadataApi> = {
       factory: jest.fn(),
-      imports: [],
     };
 
     return fixture;

--- a/packages/iocuak/src/containerModuleTask/mocks/models/api/ContainerModuleMetadataApiMocks.ts
+++ b/packages/iocuak/src/containerModuleTask/mocks/models/api/ContainerModuleMetadataApiMocks.ts
@@ -7,7 +7,6 @@ export class ContainerModuleMetadataApiMocks {
     const fixture: jest.Mocked<ContainerModuleMetadataApi> = {
       factory: jest.fn(),
       imports: [],
-      injects: [],
     };
 
     return fixture;
@@ -26,8 +25,26 @@ export class ContainerModuleMetadataApiMocks {
     const fixture: jest.Mocked<ContainerModuleMetadataApi> = {
       factory: jest.fn(),
       imports: [],
-      injects: [],
     };
+
+    return fixture;
+  }
+
+  public static get withInjects(): jest.Mocked<ContainerModuleFactoryMetadataApi> {
+    const fixture: jest.Mocked<ContainerModuleMetadataApi> = {
+      ...ContainerModuleMetadataApiMocks.anyContainerModuleFactoryMetadataApi,
+      injects: ['service-id'],
+    };
+
+    return fixture;
+  }
+
+  public static get withNoInjects(): jest.Mocked<ContainerModuleFactoryMetadataApi> {
+    const fixture: jest.Mocked<ContainerModuleMetadataApi> = {
+      ...ContainerModuleMetadataApiMocks.anyContainerModuleFactoryMetadataApi,
+    };
+
+    delete fixture.injects;
 
     return fixture;
   }

--- a/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleFactoryMetadataApi.ts
+++ b/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleFactoryMetadataApi.ts
@@ -6,5 +6,5 @@ export interface ContainerModuleFactoryMetadataApi<
   TArgs extends unknown[] = unknown[],
 > extends ContainerModuleMetadataBaseApi {
   factory: (...args: TArgs) => ContainerModuleApi | Promise<ContainerModuleApi>;
-  injects: ServiceId[];
+  injects?: ServiceId[];
 }

--- a/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleMetadataBaseApi.ts
+++ b/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleMetadataBaseApi.ts
@@ -1,5 +1,5 @@
 import { ContainerModuleMetadataApi } from './ContainerModuleMetadataApi';
 
 export interface ContainerModuleMetadataBaseApi {
-  imports: ContainerModuleMetadataApi[];
+  imports?: ContainerModuleMetadataApi[];
 }

--- a/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleMetadata.spec.ts
+++ b/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleMetadata.spec.ts
@@ -161,6 +161,44 @@ describe(convertToContainerModuleMetadata.name, () => {
     });
   });
 
+  describe('having a ContainerModuleClassMetadataApi with no imports', () => {
+    let containerModuleClassMetadataApiMock: jest.Mocked<ContainerModuleClassMetadataApi>;
+
+    beforeAll(() => {
+      containerModuleClassMetadataApiMock =
+        ContainerModuleMetadataApiMocks.anyContainerModuleClassMetadataApi;
+
+      delete containerModuleClassMetadataApiMock.imports;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = convertToContainerModuleMetadata(
+          containerModuleClassMetadataApiMock,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should return a ContainerModuleMetadata', () => {
+        const expected: ContainerModuleClassMetadata = {
+          imports: [],
+          loader: expect.any(
+            Function,
+          ) as ContainerModuleClassMetadata['loader'],
+          moduleType: containerModuleClassMetadataApiMock.module,
+          type: ContainerModuleMetadataType.clazz,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
   describe('having a ContainerModuleFactoryMetadataApi', () => {
     let containerModuleFactoryMetadataApiMock: jest.Mocked<ContainerModuleFactoryMetadataApi>;
 

--- a/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleMetadata.spec.ts
+++ b/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleMetadata.spec.ts
@@ -1,6 +1,7 @@
 jest.mock('./convertToContainerModule');
 jest.mock('./convertToContainerModuleAsync');
 
+import { ServiceId } from '../../../common/models/domain/ServiceId';
 import { ContainerModuleApi } from '../../../container/modules/api/ContainerModuleApi';
 import { ContainerModule } from '../../../container/modules/domain/ContainerModule';
 import { ContainerBindingService } from '../../../container/services/domain/ContainerBindingService';
@@ -190,7 +191,7 @@ describe(convertToContainerModuleMetadata.name, () => {
             Function,
           ) as ContainerModuleFactoryMetadata['factory'],
           imports: expect.any(Array) as ContainerModuleMetadata[],
-          injects: [...containerModuleFactoryMetadataApiMock.injects],
+          injects: expect.any(Array) as ServiceId[],
           type: ContainerModuleMetadataType.factory,
         };
 
@@ -305,6 +306,78 @@ describe(convertToContainerModuleMetadata.name, () => {
     });
   });
 
+  describe('having a ContainerModuleFactoryMetadataApi with injects', () => {
+    let containerModuleFactoryMetadataApiMock: jest.Mocked<ContainerModuleFactoryMetadataApi>;
+
+    beforeAll(() => {
+      containerModuleFactoryMetadataApiMock =
+        ContainerModuleMetadataApiMocks.withInjects;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = convertToContainerModuleMetadata(
+          containerModuleFactoryMetadataApiMock,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should return a ContainerModuleMetadata', () => {
+        const expected: ContainerModuleMetadata = {
+          factory: expect.any(
+            Function,
+          ) as ContainerModuleFactoryMetadata['factory'],
+          imports: expect.any(Array) as ContainerModuleMetadata[],
+          injects: containerModuleFactoryMetadataApiMock.injects as ServiceId[],
+          type: ContainerModuleMetadataType.factory,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe('having a ContainerModuleFactoryMetadataApi with no injects', () => {
+    let containerModuleFactoryMetadataApiMock: jest.Mocked<ContainerModuleFactoryMetadataApi>;
+
+    beforeAll(() => {
+      containerModuleFactoryMetadataApiMock =
+        ContainerModuleMetadataApiMocks.withNoInjects;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = convertToContainerModuleMetadata(
+          containerModuleFactoryMetadataApiMock,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should return a ContainerModuleMetadata', () => {
+        const expected: ContainerModuleMetadata = {
+          factory: expect.any(
+            Function,
+          ) as ContainerModuleFactoryMetadata['factory'],
+          imports: expect.any(Array) as ContainerModuleMetadata[],
+          injects: [],
+          type: ContainerModuleMetadataType.factory,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
   describe('having a ContainerModuleFactoryMetadataApi with imports', () => {
     let dependencyContainerModuleFactoryMetadataApiMock: jest.Mocked<ContainerModuleFactoryMetadataApi>;
     let containerModuleFactoryMetadataApiMock: jest.Mocked<ContainerModuleFactoryMetadataApi>;
@@ -342,13 +415,11 @@ describe(convertToContainerModuleMetadata.name, () => {
                 Function,
               ) as ContainerModuleFactoryMetadata['factory'],
               imports: expect.any(Array) as ContainerModuleMetadata[],
-              injects: [
-                ...dependencyContainerModuleFactoryMetadataApiMock.injects,
-              ],
+              injects: expect.any(Array) as ServiceId[],
               type: ContainerModuleMetadataType.factory,
             },
           ],
-          injects: [...containerModuleFactoryMetadataApiMock.injects],
+          injects: expect.any(Array) as ServiceId[],
           type: ContainerModuleMetadataType.factory,
         };
 

--- a/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleMetadata.ts
+++ b/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleMetadata.ts
@@ -39,9 +39,8 @@ function convertToContainerModuleClassMetadata(
 ): ContainerModuleClassMetadata {
   const containerModuleClassMetadata: ContainerModuleClassMetadata<ContainerModuleApi> =
     {
-      imports: containerModuleClassMetadataApi.imports.map(
-        (containerModuleImport: ContainerModuleMetadataApi) =>
-          convertToContainerModuleMetadata(containerModuleImport),
+      imports: convertToContainerModuleMetadataArray(
+        containerModuleClassMetadataApi.imports,
       ),
       loader: (
         containerModuleApi: ContainerModuleApi,
@@ -60,6 +59,23 @@ function convertToContainerModuleClassMetadata(
   return containerModuleClassMetadata as ContainerModuleClassMetadata;
 }
 
+function convertToContainerModuleMetadataArray(
+  containerModuleMetadataApiImports: ContainerModuleMetadataApi[] | undefined,
+): ContainerModuleMetadata[] {
+  let containerModuleMetadataArray: ContainerModuleMetadata[];
+
+  if (containerModuleMetadataApiImports === undefined) {
+    containerModuleMetadataArray = [];
+  } else {
+    containerModuleMetadataArray = containerModuleMetadataApiImports.map(
+      (containerModuleImport: ContainerModuleMetadataApi) =>
+        convertToContainerModuleMetadata(containerModuleImport),
+    );
+  }
+
+  return containerModuleMetadataArray;
+}
+
 function convertToContainerModuleFactoryMetadata<TArgs extends unknown[]>(
   containerModuleFactoryMetadataApi: ContainerModuleFactoryMetadataApi<TArgs>,
 ): ContainerModuleFactoryMetadata<TArgs> {
@@ -72,9 +88,8 @@ function convertToContainerModuleFactoryMetadata<TArgs extends unknown[]>(
       factory: convertToContainerModuleMetadataFactory(
         containerModuleFactoryMetadataApi.factory,
       ),
-      imports: containerModuleFactoryMetadataApi.imports.map(
-        (containerModuleImport: ContainerModuleMetadataApi) =>
-          convertToContainerModuleMetadata(containerModuleImport),
+      imports: convertToContainerModuleMetadataArray(
+        containerModuleFactoryMetadataApi.imports,
       ),
       injects: containerModuleFactoryMetadataInjects,
       type: ContainerModuleMetadataType.factory,

--- a/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleMetadata.ts
+++ b/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleMetadata.ts
@@ -1,5 +1,6 @@
 import { isPromiseLike } from '@cuaklabs/cuaktask';
 
+import { ServiceId } from '../../../common/models/domain/ServiceId';
 import { ContainerModuleApi } from '../../../container/modules/api/ContainerModuleApi';
 import { ContainerModule } from '../../../container/modules/domain/ContainerModule';
 import { ContainerBindingService } from '../../../container/services/domain/ContainerBindingService';
@@ -62,6 +63,10 @@ function convertToContainerModuleClassMetadata(
 function convertToContainerModuleFactoryMetadata<TArgs extends unknown[]>(
   containerModuleFactoryMetadataApi: ContainerModuleFactoryMetadataApi<TArgs>,
 ): ContainerModuleFactoryMetadata<TArgs> {
+  const containerModuleFactoryMetadataInjects: ServiceId[] = [
+    ...(containerModuleFactoryMetadataApi.injects ?? []),
+  ];
+
   const containerModuleFactoryMetadata: ContainerModuleFactoryMetadata<TArgs> =
     {
       factory: convertToContainerModuleMetadataFactory(
@@ -71,7 +76,7 @@ function convertToContainerModuleFactoryMetadata<TArgs extends unknown[]>(
         (containerModuleImport: ContainerModuleMetadataApi) =>
           convertToContainerModuleMetadata(containerModuleImport),
       ),
-      injects: [...containerModuleFactoryMetadataApi.injects],
+      injects: containerModuleFactoryMetadataInjects,
       type: ContainerModuleMetadataType.factory,
     };
 


### PR DESCRIPTION
### Changed
- Updated `ContainerModuleMetadata.imports` to be optional.
- Updated `ContainerModuleMetadata.injects` to be optional.