### PR TITLE
Release @cuaklabs/iocuak@0.2.1

### DIFF
--- a/packages/iocuak/CHANGELOG.md
+++ b/packages/iocuak/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
-## [UNRELEASED]
+## 0.2.1 - 2022-04-30
 
 ### Changed
 - Updated `Container.get` to create instance of newable unbinded types.

--- a/packages/iocuak/package.json
+++ b/packages/iocuak/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuaklabs/iocuak",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Minimal inversion of control container inspired by InversifyJS (https://inversify.io/)",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
## 0.2.1 - 2022-04-30

### Changed
- Updated `Container.get` to create instance of newable unbinded types.
- Updated `ContainerModuleMetadata` to allow class metadata
- Updated `ContainerModuleMetadata.imports` to be optional.
- Updated `ContainerModuleMetadata.injects` to be optional.