### PR TITLE
Allow simpler container metadata api

### DIFF
--- a/packages/iocuak/CHANGELOG.md
+++ b/packages/iocuak/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
+## [UNRELEASED]
+
+### Changed
+- Updated `ContainerModuleMetadata` to allow module classes and modules.
+
+
+
+
 ## 0.2.1 - 2022-04-30
 
 ### Changed

--- a/packages/iocuak/src/common/utils/isFunction.ts
+++ b/packages/iocuak/src/common/utils/isFunction.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function isFunction(value: unknown): value is Function {
+  return typeof value === 'function';
+}

--- a/packages/iocuak/src/container/utils/api/isContainerModuleApi.ts
+++ b/packages/iocuak/src/container/utils/api/isContainerModuleApi.ts
@@ -1,0 +1,9 @@
+import { isFunction } from '../../../common/utils/isFunction';
+import { ContainerModuleApi } from '../../modules/api/ContainerModuleApi';
+
+export function isContainerModuleApi(
+  value: unknown,
+): value is ContainerModuleApi {
+  // eslint-disable-next-line @typescript-eslint/unbound-method
+  return isFunction((value as ContainerModuleApi).load);
+}

--- a/packages/iocuak/src/containerModuleTask/mocks/models/api/ContainerModuleMetadataApiMocks.ts
+++ b/packages/iocuak/src/containerModuleTask/mocks/models/api/ContainerModuleMetadataApiMocks.ts
@@ -20,7 +20,7 @@ export class ContainerModuleMetadataApiMocks {
   }
 
   public static get anyContainerModuleFactoryMetadataApi(): jest.Mocked<ContainerModuleFactoryMetadataApi> {
-    const fixture: jest.Mocked<ContainerModuleMetadataApi> = {
+    const fixture: jest.Mocked<ContainerModuleFactoryMetadataApi> = {
       factory: jest.fn(),
     };
 
@@ -28,7 +28,7 @@ export class ContainerModuleMetadataApiMocks {
   }
 
   public static get withInjects(): jest.Mocked<ContainerModuleFactoryMetadataApi> {
-    const fixture: jest.Mocked<ContainerModuleMetadataApi> = {
+    const fixture: jest.Mocked<ContainerModuleFactoryMetadataApi> = {
       ...ContainerModuleMetadataApiMocks.anyContainerModuleFactoryMetadataApi,
       injects: ['service-id'],
     };
@@ -37,7 +37,7 @@ export class ContainerModuleMetadataApiMocks {
   }
 
   public static get withNoInjects(): jest.Mocked<ContainerModuleFactoryMetadataApi> {
-    const fixture: jest.Mocked<ContainerModuleMetadataApi> = {
+    const fixture: jest.Mocked<ContainerModuleFactoryMetadataApi> = {
       ...ContainerModuleMetadataApiMocks.anyContainerModuleFactoryMetadataApi,
     };
 

--- a/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleMetadataApi.ts
+++ b/packages/iocuak/src/containerModuleTask/models/api/ContainerModuleMetadataApi.ts
@@ -1,6 +1,10 @@
+import { Newable } from '../../../common/models/domain/Newable';
+import { ContainerModuleApi } from '../../../container/modules/api/ContainerModuleApi';
 import { ContainerModuleClassMetadataApi } from './ContainerModuleClassMetadataApi';
 import { ContainerModuleFactoryMetadataApi } from './ContainerModuleFactoryMetadataApi';
 
 export type ContainerModuleMetadataApi<TArgs extends unknown[] = unknown[]> =
+  | ContainerModuleApi
   | ContainerModuleFactoryMetadataApi<TArgs>
-  | ContainerModuleClassMetadataApi;
+  | ContainerModuleClassMetadataApi
+  | Newable<ContainerModuleApi>;

--- a/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleMetadata.spec.ts
+++ b/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleMetadata.spec.ts
@@ -1,6 +1,7 @@
 jest.mock('./convertToContainerModule');
 jest.mock('./convertToContainerModuleAsync');
 
+import { Newable } from '../../../common/models/domain/Newable';
 import { ServiceId } from '../../../common/models/domain/ServiceId';
 import { ContainerModuleApi } from '../../../container/modules/api/ContainerModuleApi';
 import { ContainerModule } from '../../../container/modules/domain/ContainerModule';
@@ -18,6 +19,118 @@ import { convertToContainerModuleAsync } from './convertToContainerModuleAsync';
 import { convertToContainerModuleMetadata } from './convertToContainerModuleMetadata';
 
 describe(convertToContainerModuleMetadata.name, () => {
+  describe('having a ContainerModuleApi', () => {
+    let containerModuleFactoryMetadataApiMock: jest.Mocked<ContainerModuleApi>;
+
+    beforeAll(() => {
+      containerModuleFactoryMetadataApiMock = {
+        load: jest.fn(),
+      };
+    });
+
+    describe('when called', () => {
+      let containerModuleMetadata: ContainerModuleFactoryMetadata;
+      let result: unknown;
+
+      beforeAll(() => {
+        result = convertToContainerModuleMetadata(
+          containerModuleFactoryMetadataApiMock,
+        );
+
+        containerModuleMetadata = result as ContainerModuleFactoryMetadata;
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should return a ContainerModuleMetadata', () => {
+        const expected: ContainerModuleFactoryMetadata = {
+          factory: expect.any(
+            Function,
+          ) as ContainerModuleFactoryMetadata['factory'],
+          imports: [],
+          injects: [],
+          type: ContainerModuleMetadataType.factory,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+
+      describe('when factory is called and containerModuleMetadataApi.factory returns a non promise', () => {
+        let containerModuleFixture: ContainerModule;
+        let argumentsFixture: unknown[];
+        let result: unknown;
+
+        beforeAll(() => {
+          containerModuleFixture = {
+            _tag: 'containerModule',
+          } as unknown as ContainerModule;
+
+          (
+            convertToContainerModule as jest.Mock<ContainerModule>
+          ).mockReturnValueOnce(containerModuleFixture);
+
+          argumentsFixture = [Symbol()];
+
+          result = containerModuleMetadata.factory(...argumentsFixture);
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call convertToContainerModule()', () => {
+          expect(convertToContainerModule).toHaveBeenCalledTimes(1);
+          expect(convertToContainerModule).toHaveBeenCalledWith(
+            containerModuleFactoryMetadataApiMock,
+          );
+        });
+
+        it('should return a ContainerModule', () => {
+          expect(result).toBe(containerModuleFixture);
+        });
+      });
+    });
+  });
+
+  describe('having a ContainerModuleApi Newable', () => {
+    let containerModuleClassMetadataApiMock: jest.Mocked<
+      Newable<ContainerModuleApi>
+    >;
+
+    beforeAll(() => {
+      containerModuleClassMetadataApiMock = jest.fn();
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      beforeAll(() => {
+        result = convertToContainerModuleMetadata(
+          containerModuleClassMetadataApiMock,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should return a ContainerModuleMetadata', () => {
+        const expected: ContainerModuleClassMetadata = {
+          imports: [],
+          loader: expect.any(
+            Function,
+          ) as ContainerModuleClassMetadata['loader'],
+          moduleType: containerModuleClassMetadataApiMock,
+          type: ContainerModuleMetadataType.clazz,
+        };
+
+        expect(result).toStrictEqual(expected);
+      });
+    });
+  });
+
   describe('having a ContainerModuleClassMetadataApi', () => {
     let containerModuleClassMetadataApiMock: jest.Mocked<ContainerModuleClassMetadataApi>;
 

--- a/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleMetadata.ts
+++ b/packages/iocuak/src/containerModuleTask/utils/api/convertToContainerModuleMetadata.ts
@@ -1,9 +1,11 @@
 import { isPromiseLike } from '@cuaklabs/cuaktask';
 
 import { ServiceId } from '../../../common/models/domain/ServiceId';
+import { isFunction } from '../../../common/utils/isFunction';
 import { ContainerModuleApi } from '../../../container/modules/api/ContainerModuleApi';
 import { ContainerModule } from '../../../container/modules/domain/ContainerModule';
 import { ContainerBindingService } from '../../../container/services/domain/ContainerBindingService';
+import { isContainerModuleApi } from '../../../container/utils/api/isContainerModuleApi';
 import { MetadataService } from '../../../metadata/services/domain/MetadataService';
 import { ContainerModuleClassMetadataApi } from '../../models/api/ContainerModuleClassMetadataApi';
 import { ContainerModuleFactoryMetadataApi } from '../../models/api/ContainerModuleFactoryMetadataApi';
@@ -21,14 +23,26 @@ export function convertToContainerModuleMetadata<TArgs extends unknown[]>(
 ): ContainerModuleMetadata<TArgs> {
   let containerModuleMetadata: ContainerModuleMetadata<TArgs>;
 
-  if (isContainerModuleClassMetadataApi(containerModuleMetadataApi)) {
-    containerModuleMetadata = convertToContainerModuleClassMetadata(
-      containerModuleMetadataApi,
-    );
+  if (isFunction(containerModuleMetadataApi)) {
+    containerModuleMetadata = convertToContainerModuleClassMetadata({
+      module: containerModuleMetadataApi,
+    });
   } else {
-    containerModuleMetadata = convertToContainerModuleFactoryMetadata(
-      containerModuleMetadataApi,
-    );
+    if (isContainerModuleApi(containerModuleMetadataApi)) {
+      containerModuleMetadata = convertToContainerModuleFactoryMetadata({
+        factory: () => containerModuleMetadataApi,
+      });
+    } else {
+      if (isContainerModuleClassMetadataApi(containerModuleMetadataApi)) {
+        containerModuleMetadata = convertToContainerModuleClassMetadata(
+          containerModuleMetadataApi,
+        );
+      } else {
+        containerModuleMetadata = convertToContainerModuleFactoryMetadata(
+          containerModuleMetadataApi,
+        );
+      }
+    }
   }
 
   return containerModuleMetadata;

--- a/packages/iocuak/src/e2e/definitions/container/parameters/containerModuleMetadata/ContainerModuleMetadataParameter.ts
+++ b/packages/iocuak/src/e2e/definitions/container/parameters/containerModuleMetadata/ContainerModuleMetadataParameter.ts
@@ -2,8 +2,10 @@ import sinon from 'sinon';
 
 import { ContainerModuleMetadataApi } from '../../../../../containerModuleTask/models/api/ContainerModuleMetadataApi';
 
-export interface ContainerModuleMetadataParameter {
-  containerModuleMetadata: ContainerModuleMetadataApi;
+export interface ContainerModuleMetadataParameter<
+  TContainerModuleMetadata extends ContainerModuleMetadataApi = ContainerModuleMetadataApi,
+> {
+  containerModuleMetadata: TContainerModuleMetadata;
   importParameters?: ContainerModuleMetadataParameter[];
   loadSpy: sinon.SinonSpy;
   spy: sinon.SinonSpy;

--- a/packages/iocuak/src/e2e/definitions/container/parameters/containerModuleMetadata/getContainerModuleMetadataWithContainerModuleClassMetadataImports.ts
+++ b/packages/iocuak/src/e2e/definitions/container/parameters/containerModuleMetadata/getContainerModuleMetadataWithContainerModuleClassMetadataImports.ts
@@ -12,13 +12,11 @@ import { ContainerModuleMetadataParameter } from './ContainerModuleMetadataParam
 import { getContainerModuleMetadataWithModuleParameter } from './getContainerModuleMetadataWithModuleParameter';
 
 export function getContainerModuleMetadataWithContainerModuleClassMetadataImports(): ContainerModuleMetadataParameter {
-  const containerModuleClassMetadataParameter: ContainerModuleMetadataParameter =
+  const containerModuleClassMetadataParameter: ContainerModuleMetadataParameter<ContainerModuleClassMetadataApi> =
     getContainerModuleMetadataWithModuleParameter();
 
   const containerModuleClassMetadataParameterClass: Newable<ContainerModuleApi> =
-    (
-      containerModuleClassMetadataParameter.containerModuleMetadata as ContainerModuleClassMetadataApi
-    ).module;
+    containerModuleClassMetadataParameter.containerModuleMetadata.module;
 
   const typeServiceParameter: TypeServiceParameter =
     getTypeServiceWithNoDependenciesParameter();

--- a/packages/iocuak/src/e2e/definitions/container/parameters/containerModuleMetadata/getContainerModuleMetadataWithModuleParameter.ts
+++ b/packages/iocuak/src/e2e/definitions/container/parameters/containerModuleMetadata/getContainerModuleMetadataWithModuleParameter.ts
@@ -6,7 +6,7 @@ import { ContainerModuleClassMetadataApi } from '../../../../../containerModuleT
 import { injectable } from '../../../../../metadata/decorators/injectable';
 import { ContainerModuleMetadataParameter } from './ContainerModuleMetadataParameter';
 
-export function getContainerModuleMetadataWithModuleParameter(): ContainerModuleMetadataParameter {
+export function getContainerModuleMetadataWithModuleParameter(): ContainerModuleMetadataParameter<ContainerModuleClassMetadataApi> {
   // eslint-disable-next-line import/no-named-as-default-member
   const loadSpy: sinon.SinonSpy = sinon.spy();
   // eslint-disable-next-line import/no-named-as-default-member
@@ -29,11 +29,12 @@ export function getContainerModuleMetadataWithModuleParameter(): ContainerModule
     module: ContainerModuleClass,
   };
 
-  const containerModuleMetadaParameter: ContainerModuleMetadataParameter = {
-    containerModuleMetadata,
-    loadSpy,
-    spy,
-  };
+  const containerModuleMetadaParameter: ContainerModuleMetadataParameter<ContainerModuleClassMetadataApi> =
+    {
+      containerModuleMetadata,
+      loadSpy,
+      spy,
+    };
 
   return containerModuleMetadaParameter;
 }

--- a/packages/iocuak/src/metadata/utils/domain/lazyGetBindingOrThrow.ts
+++ b/packages/iocuak/src/metadata/utils/domain/lazyGetBindingOrThrow.ts
@@ -1,5 +1,6 @@
 import { Newable } from '../../../common/models/domain/Newable';
 import { ServiceId } from '../../../common/models/domain/ServiceId';
+import { isFunction } from '../../../common/utils/isFunction';
 import { stringifyServiceId } from '../../../utils/stringifyServiceId';
 import { TypeBinding } from '../../models/domain/TypeBinding';
 import { MetadataService } from '../../services/domain/MetadataService';
@@ -9,7 +10,7 @@ export function lazyGetBindingOrThrow<TInstance, TArgs extends unknown[]>(
   serviceId: ServiceId,
   metadataService: MetadataService,
 ): TypeBinding<TInstance, TArgs> {
-  if (serviceId instanceof Function) {
+  if (isFunction(serviceId)) {
     return getBindingOrThrow(
       serviceId as Newable<TInstance, TArgs>,
       metadataService,


### PR DESCRIPTION
### Changed
- Updated `ContainerModuleMetadataApi` to allow module classes and modules.