### PR TITLE
Add create array task

### DIFF
--- a/packages/iocuak/src/task/fixtures/domain/CreateArrayTaskKindFixtures.ts
+++ b/packages/iocuak/src/task/fixtures/domain/CreateArrayTaskKindFixtures.ts
@@ -1,0 +1,13 @@
+import { CreateArrayTaskKind } from '../../models/domain/CreateArrayTaskKind';
+import { TaskKindType } from '../../models/domain/TaskKindType';
+
+export class CreateArrayTaskKindFixtures {
+  public static get any(): CreateArrayTaskKind {
+    const fixture: CreateArrayTaskKind = {
+      requestId: Symbol(),
+      type: TaskKindType.createArray,
+    };
+
+    return fixture;
+  }
+}

--- a/packages/iocuak/src/task/models/cuaktask/CreateArrayTask.spec.ts
+++ b/packages/iocuak/src/task/models/cuaktask/CreateArrayTask.spec.ts
@@ -1,0 +1,28 @@
+import { CreateArrayTaskKindFixtures } from '../../fixtures/domain/CreateArrayTaskKindFixtures';
+import { CreateArrayTask } from './CreateArrayTask';
+
+describe(CreateArrayTask.name, () => {
+  let createArrayTask: CreateArrayTask;
+
+  beforeAll(() => {
+    createArrayTask = new CreateArrayTask(CreateArrayTaskKindFixtures.any);
+  });
+
+  describe('.perform()', () => {
+    describe('when called, and dependencies match metadata', () => {
+      let instancesFixture: unknown[];
+
+      let result: unknown;
+
+      beforeAll(() => {
+        instancesFixture = [Symbol(), Symbol()];
+
+        result = createArrayTask.perform(...instancesFixture);
+      });
+
+      it('should return instances', () => {
+        expect(result).toStrictEqual(instancesFixture);
+      });
+    });
+  });
+});

--- a/packages/iocuak/src/task/models/cuaktask/CreateArrayTask.ts
+++ b/packages/iocuak/src/task/models/cuaktask/CreateArrayTask.ts
@@ -1,0 +1,27 @@
+import { BaseDependentTask, DependentTask } from '@cuaklabs/cuaktask';
+
+import { CreateArrayTaskKind } from '../domain/CreateArrayTaskKind';
+import { TaskKind } from '../domain/TaskKind';
+
+export class CreateArrayTask<TInstance = unknown> extends BaseDependentTask<
+  CreateArrayTaskKind,
+  TaskKind,
+  TInstance[],
+  TInstance[]
+> {
+  constructor(
+    kind: CreateArrayTaskKind,
+    dependencies: DependentTask<
+      TaskKind,
+      TaskKind,
+      unknown[],
+      TInstance
+    >[] = [],
+  ) {
+    super(kind, dependencies);
+  }
+
+  protected innerPerform(...instances: TInstance[]): TInstance[] {
+    return instances;
+  }
+}

--- a/packages/iocuak/src/task/models/cuaktask/CreateInstanceTask.spec.ts
+++ b/packages/iocuak/src/task/models/cuaktask/CreateInstanceTask.spec.ts
@@ -3,8 +3,6 @@ jest.mock('../../../binding/utils/domain/lazyGetBindingOrThrow');
 import { TypeBindingFixtures } from '../../../binding/fixtures/domain/TypeBindingFixtures';
 import { ValueBindingFixtures } from '../../../binding/fixtures/domain/ValueBindingFixtures';
 import { Binding } from '../../../binding/models/domain/Binding';
-import { BindingScope } from '../../../binding/models/domain/BindingScope';
-import { BindingType } from '../../../binding/models/domain/BindingType';
 import { TypeBinding } from '../../../binding/models/domain/TypeBinding';
 import { ValueBinding } from '../../../binding/models/domain/ValueBinding';
 import { BindingService } from '../../../binding/services/domain/BindingService';

--- a/packages/iocuak/src/task/models/domain/BaseServiceTaskKind.ts
+++ b/packages/iocuak/src/task/models/domain/BaseServiceTaskKind.ts
@@ -1,0 +1,9 @@
+import { ServiceId } from '../../../common/models/domain/ServiceId';
+import { BaseTaskKind } from './BaseTaskKind';
+import { TaskKindType } from './TaskKindType';
+
+export interface BaseServiceTaskKind<
+  TTaskKindType extends TaskKindType = TaskKindType,
+> extends BaseTaskKind<TTaskKindType> {
+  id: ServiceId;
+}

--- a/packages/iocuak/src/task/models/domain/BaseTaskKind.ts
+++ b/packages/iocuak/src/task/models/domain/BaseTaskKind.ts
@@ -1,10 +1,8 @@
-import { ServiceId } from '../../../common/models/domain/ServiceId';
 import { TaskKindType } from './TaskKindType';
 
 export interface BaseTaskKind<
   TTaskKindType extends TaskKindType = TaskKindType,
 > {
-  id: ServiceId;
   requestId: symbol;
   type: TTaskKindType;
 }

--- a/packages/iocuak/src/task/models/domain/CreateArrayTaskKind.ts
+++ b/packages/iocuak/src/task/models/domain/CreateArrayTaskKind.ts
@@ -1,0 +1,4 @@
+import { BaseTaskKind } from './BaseTaskKind';
+import { TaskKindType } from './TaskKindType';
+
+export type CreateArrayTaskKind = BaseTaskKind<TaskKindType.createArray>;

--- a/packages/iocuak/src/task/models/domain/CreateInstanceTaskKind.ts
+++ b/packages/iocuak/src/task/models/domain/CreateInstanceTaskKind.ts
@@ -1,4 +1,5 @@
-import { BaseTaskKind } from './BaseTaskKind';
+import { BaseServiceTaskKind } from './BaseServiceTaskKind';
 import { TaskKindType } from './TaskKindType';
 
-export type CreateInstanceTaskKind = BaseTaskKind<TaskKindType.createInstance>;
+export type CreateInstanceTaskKind =
+  BaseServiceTaskKind<TaskKindType.createInstance>;

--- a/packages/iocuak/src/task/models/domain/GetInstanceDependenciesTaskKind.ts
+++ b/packages/iocuak/src/task/models/domain/GetInstanceDependenciesTaskKind.ts
@@ -1,8 +1,8 @@
 import { ClassMetadata } from '../../../classMetadata/models/domain/ClassMetadata';
-import { BaseTaskKind } from './BaseTaskKind';
+import { BaseServiceTaskKind } from './BaseServiceTaskKind';
 import { TaskKindType } from './TaskKindType';
 
 export interface GetInstanceDependenciesTaskKind
-  extends BaseTaskKind<TaskKindType.getInstanceDependencies> {
+  extends BaseServiceTaskKind<TaskKindType.getInstanceDependencies> {
   metadata: ClassMetadata;
 }

--- a/packages/iocuak/src/task/models/domain/TaskKindType.ts
+++ b/packages/iocuak/src/task/models/domain/TaskKindType.ts
@@ -1,4 +1,5 @@
 export enum TaskKindType {
+  createArray = 'createArray',
   createInstance = 'createInstance',
   getInstanceDependencies = 'getInstanceDependencies',
 }


### PR DESCRIPTION
### Added
- Added `CreateArrayTask`.
- Added `BaseServiceTaskKind`.

### Changed
- Updated TaskKindType with `createArray`.
- Updated `CreateInstanceTaskKind` and `GetServiceDependenciesTaskKind` to extend `BaseServiceTaskKind`.