### PR TITLE
Update task kind with get cached instance task kind

### DIFF
--- a/packages/iocuak/src/createInstanceTask/models/cuaktask/CreateInstanceTaskGraphExpandOperationContext.ts
+++ b/packages/iocuak/src/createInstanceTask/models/cuaktask/CreateInstanceTaskGraphExpandOperationContext.ts
@@ -1,25 +1,17 @@
 import * as cuaktask from '@cuaklabs/cuaktask';
 
-import { TypeBinding } from '../../../binding/models/domain/TypeBinding';
 import { TaskGraphExpandOperationContext } from '../../../common/models/cuaktask/TaskGraphExpandOperationContext';
 import { ServiceId } from '../../../common/models/domain/ServiceId';
-import { CreateInstanceTaskKind } from '../domain/CreateInstanceTaskKind';
 import { TaskKind } from '../domain/TaskKind';
-
-type TypeBindingCreateInstanceTaskKindGraphNode =
-  cuaktask.TaskDependencyKindGraphNode<
-    CreateInstanceTaskKind<TypeBinding>,
-    TaskKind
-  >;
 
 export interface CreateInstanceTaskGraphExpandOperationContext
   extends TaskGraphExpandOperationContext {
   serviceIdToRequestCreateInstanceTaskKindNode: Map<
     ServiceId,
-    TypeBindingCreateInstanceTaskKindGraphNode
+    cuaktask.NodeDependency<cuaktask.Task<TaskKind>>
   >;
   serviceIdToSingletonCreateInstanceTaskKindNode: Map<
     ServiceId,
-    TypeBindingCreateInstanceTaskKindGraphNode
+    cuaktask.NodeDependency<cuaktask.Task<TaskKind>>
   >;
 }

--- a/packages/iocuak/src/createInstanceTask/models/domain/TaskKind.ts
+++ b/packages/iocuak/src/createInstanceTask/models/domain/TaskKind.ts
@@ -1,8 +1,10 @@
 import { CreateInstanceRootTaskKind } from './CreateInstanceRootTaskKind';
 import { CreateInstanceTaskKind } from './CreateInstanceTaskKind';
+import { GetCachedInstanceTaskKind } from './GetCachedInstanceTaskKind';
 import { GetInstanceDependenciesTaskKind } from './GetInstanceDependenciesTaskKind';
 
 export type TaskKind =
   | CreateInstanceTaskKind
   | CreateInstanceRootTaskKind
+  | GetCachedInstanceTaskKind
   | GetInstanceDependenciesTaskKind;

--- a/packages/iocuak/src/createInstanceTask/modules/CreateInstancesTaskDependenciesOperation.ts
+++ b/packages/iocuak/src/createInstanceTask/modules/CreateInstancesTaskDependenciesOperation.ts
@@ -88,6 +88,8 @@ export class CreateInstancesTaskDependenciesOperation {
         throw new Error('Unsupported type');
       case TaskKindType.createInstanceRoot:
         return this.#getCreateInstanceTaskKindDependencies(this.#taskKind);
+      default:
+        throw new Error('Unexpected task kind');
     }
   }
 

--- a/packages/iocuak/src/createInstanceTask/modules/TaskBuilderWithNoDependencies.ts
+++ b/packages/iocuak/src/createInstanceTask/modules/TaskBuilderWithNoDependencies.ts
@@ -46,6 +46,8 @@ export class TaskBuilderWithNoDependencies {
             TArgs,
             TReturn
           >;
+        default:
+          throw new Error('Unexpected task kind');
       }
     } else {
       throw new Error('Task kind not supported');

--- a/packages/iocuak/src/createInstanceTask/modules/TaskKindSet.ts
+++ b/packages/iocuak/src/createInstanceTask/modules/TaskKindSet.ts
@@ -61,6 +61,8 @@ export class TaskKindSet implements SetLike<TaskKind> {
       case TaskKindType.createInstanceRoot:
       case TaskKindType.getInstanceDependencies:
         return elem.id;
+      default:
+        throw new Error('Unexpected task kind');
     }
   }
 

--- a/packages/iocuak/src/createInstanceTask/modules/cuaktask/CreateInstanceTaskLazyNode.spec.ts
+++ b/packages/iocuak/src/createInstanceTask/modules/cuaktask/CreateInstanceTaskLazyNode.spec.ts
@@ -3,6 +3,8 @@ import { Task } from '@cuaklabs/cuaktask';
 import { TaskGraphExpandCommand } from '../../../common/models/cuaktask/TaskGraphExpandCommand';
 import { TaskGraphExpandOperationContext } from '../../../common/models/cuaktask/TaskGraphExpandOperationContext';
 import { Handler } from '../../../common/modules/domain/Handler';
+import { TaskKind } from '../../models/domain/TaskKind';
+import { TaskKindType } from '../../models/domain/TaskKindType';
 import { CreateInstanceTaskLazyNode } from './CreateInstanceTaskLazyNode';
 
 describe(CreateInstanceTaskLazyNode.name, () => {
@@ -17,8 +19,8 @@ describe(CreateInstanceTaskLazyNode.name, () => {
     >
   >;
   let context: TaskGraphExpandOperationContext;
-  let element: Task<unknown>;
-  let taskKindType: unknown;
+  let element: Task<TaskKind>;
+  let taskKindType: TaskKindType;
 
   beforeAll(() => {
     busMock = {
@@ -29,16 +31,13 @@ describe(CreateInstanceTaskLazyNode.name, () => {
     } as unknown as TaskGraphExpandOperationContext;
     element = {
       _type: Symbol(),
-    } as unknown as Task<unknown>;
-    taskKindType = Symbol();
+    } as unknown as Task<TaskKind>;
+    taskKindType = TaskKindType.createInstance;
   });
 
   describe('.dependencies', () => {
     describe('when called', () => {
-      let createInstanceTaskLazyNode: CreateInstanceTaskLazyNode<
-        TaskGraphExpandOperationContext,
-        Task<unknown>
-      >;
+      let createInstanceTaskLazyNode: CreateInstanceTaskLazyNode;
 
       let result: unknown;
 
@@ -78,10 +77,7 @@ describe(CreateInstanceTaskLazyNode.name, () => {
     });
 
     describe('when called twice', () => {
-      let createInstanceTaskLazyNode: CreateInstanceTaskLazyNode<
-        TaskGraphExpandOperationContext,
-        Task<unknown>
-      >;
+      let createInstanceTaskLazyNode: CreateInstanceTaskLazyNode;
 
       let result: unknown;
 

--- a/packages/iocuak/src/createInstanceTask/modules/cuaktask/CreateInstanceTaskLazyNode.ts
+++ b/packages/iocuak/src/createInstanceTask/modules/cuaktask/CreateInstanceTaskLazyNode.ts
@@ -8,28 +8,29 @@ import {
 import { TaskGraphExpandCommand } from '../../../common/models/cuaktask/TaskGraphExpandCommand';
 import { TaskGraphExpandOperationContext } from '../../../common/models/cuaktask/TaskGraphExpandOperationContext';
 import { Handler } from '../../../common/modules/domain/Handler';
+import { TaskKind } from '../../models/domain/TaskKind';
+import { TaskKindType } from '../../models/domain/TaskKindType';
 
-export class CreateInstanceTaskLazyNode<
-  TContext extends TaskGraphExpandOperationContext,
-  TElem extends Task<unknown>,
-  TTaskKindType = unknown,
-> implements Node<TElem, Task<unknown>>
-{
+export class CreateInstanceTaskLazyNode implements Node<Task<TaskKind>> {
   readonly #bus: Handler<unknown, void | Promise<void>>;
-  readonly #context: TContext;
-  readonly #taskKindType: TTaskKindType;
+  readonly #context: TaskGraphExpandOperationContext;
+  readonly #taskKindType: TaskKindType;
 
-  #dependencies: NodeDependencies<Task<unknown>> | undefined;
+  #dependencies: NodeDependencies<Task<TaskKind>> | undefined;
   #isLoaded: boolean;
 
   constructor(
     bus: Handler<
-      TaskGraphExpandCommand<TContext, TTaskKindType, TElem>,
+      TaskGraphExpandCommand<
+        TaskGraphExpandOperationContext,
+        TaskKindType,
+        Task<TaskKind>
+      >,
       void | Promise<void>
     >,
-    context: TContext,
-    public readonly element: TElem,
-    taskKindType: TTaskKindType,
+    context: TaskGraphExpandOperationContext,
+    public readonly element: Task<TaskKind>,
+    taskKindType: TaskKindType,
   ) {
     this.#bus = bus;
     this.#context = context;
@@ -37,9 +38,13 @@ export class CreateInstanceTaskLazyNode<
     this.#taskKindType = taskKindType;
   }
 
-  public get dependencies(): NodeDependencies<Task<unknown>> | undefined {
+  public get dependencies(): NodeDependencies<Task<TaskKind>> | undefined {
     if (!this.#isLoaded) {
-      const command: TaskGraphExpandCommand<TContext, TTaskKindType, TElem> = {
+      const command: TaskGraphExpandCommand<
+        TaskGraphExpandOperationContext,
+        TaskKindType,
+        Task<TaskKind>
+      > = {
         context: this.#context,
         node: this,
         taskKindType: this.#taskKindType,
@@ -57,7 +62,7 @@ export class CreateInstanceTaskLazyNode<
     return this.#dependencies;
   }
 
-  public set dependencies(value: NodeDependencies<Task<unknown>> | undefined) {
+  public set dependencies(value: NodeDependencies<Task<TaskKind>> | undefined) {
     this.#dependencies = value;
   }
 }


### PR DESCRIPTION
### Changed
- Updated `TaskKind` with `GetCachedInstanceTaskKind`.
- Updated `CreateInstanceTaskLazyNode` to implement `Node<Task<TaskKind>>`.
- Updated `CreateInstanceTaskGraphExpandOperationContext` maps to store dependencies instead of nodes.