### PR TITLE
Update base create create cached scoped instance task graph node command handler to destructure array results

### DIFF
--- a/packages/iocuak/src/createInstanceTask/models/cuaktask/DestructureOneTask.spec.ts
+++ b/packages/iocuak/src/createInstanceTask/models/cuaktask/DestructureOneTask.spec.ts
@@ -18,20 +18,20 @@ jest.describe(DestructureOneTask.name, () => {
     jest.describe('when called', () => {
       let destructureOneTask: DestructureOneTask;
 
-      let paramFixture: [unknown];
+      let paramFixture: unknown;
 
       let result: unknown;
 
       jest.beforeAll(() => {
         destructureOneTask = new DestructureOneTask(destructureOneTaskKind);
 
-        paramFixture = [Symbol()];
+        paramFixture = Symbol();
 
         result = destructureOneTask.perform(paramFixture);
       });
 
       it('should return the destructure value', () => {
-        expect([result]).toStrictEqual(paramFixture);
+        expect(result).toStrictEqual(paramFixture);
       });
     });
   });

--- a/packages/iocuak/src/createInstanceTask/models/cuaktask/DestructureOneTask.ts
+++ b/packages/iocuak/src/createInstanceTask/models/cuaktask/DestructureOneTask.ts
@@ -4,12 +4,10 @@ import { DestructureOneTaskKind } from '../domain/DestructureOneTaskKind';
 
 export class DestructureOneTask extends cuaktask.BaseTask<
   DestructureOneTaskKind,
-  [[unknown]],
+  [unknown],
   unknown
 > {
-  protected innerPerform(param: [unknown]): unknown {
-    const [deconstructedParam]: [unknown] = param;
-
-    return deconstructedParam;
+  protected innerPerform(param: unknown): unknown {
+    return param;
   }
 }

--- a/packages/iocuak/src/createInstanceTask/modules/cuaktask/BaseCreateCreateCachedScopedInstanceTaskGraphNodeCommandHandler.spec.ts
+++ b/packages/iocuak/src/createInstanceTask/modules/cuaktask/BaseCreateCreateCachedScopedInstanceTaskGraphNodeCommandHandler.spec.ts
@@ -8,6 +8,7 @@ import { ReadOnlyLinkedList } from '../../../list/models/domain/ReadOnlyLinkedLi
 import { CreateInstanceTaskKindFixtures } from '../../fixtures/domain/CreateInstanceTaskKindFixtures';
 import { CreateCreateInstanceTaskGraphNodeCommand } from '../../models/cuaktask/CreateCreateInstanceTaskGraphNodeCommand';
 import { CreateInstanceTaskGraphExpandOperationContext } from '../../models/cuaktask/CreateInstanceTaskGraphExpandOperationContext';
+import { DestructureOneTask } from '../../models/cuaktask/DestructureOneTask';
 import { GetCachedInstanceTask } from '../../models/cuaktask/GetCachedInstanceTask';
 import { TaskGraphExpandCommand } from '../../models/cuaktask/TaskGraphExpandCommand';
 import { TaskKind } from '../../models/domain/TaskKind';
@@ -136,31 +137,37 @@ describe(
         });
 
         it('should return a NodeDependency', () => {
-          expect(result).toStrictEqual<
-            cuaktask.BitwiseOrNodeDependencies<cuaktask.Task<TaskKind>>
-          >({
-            nodes: [
-              {
-                dependencies: undefined,
-                element: new GetCachedInstanceTask(
-                  {
-                    binding:
-                      createInstanceTaskGraphFromTypeBindingTaskKindExpandCommand
-                        .context.taskKind.binding,
-                    requestId:
-                      createInstanceTaskGraphFromTypeBindingTaskKindExpandCommand
-                        .context.taskKind.requestId,
-                    type: TaskKindType.getCachedInstance,
-                  },
-                  containerRequestServiceFixture,
-                  containerSingletonServiceFixture,
-                ),
-              },
-              expect.any(
-                CreateInstanceTaskLazyNode,
-              ) as CreateInstanceTaskLazyNode,
-            ],
-            type: cuaktask.NodeDependenciesType.bitwiseOr,
+          expect(result).toStrictEqual<cuaktask.Node<cuaktask.Task<TaskKind>>>({
+            dependencies: {
+              nodes: [
+                {
+                  dependencies: undefined,
+                  element: new GetCachedInstanceTask(
+                    {
+                      binding:
+                        createInstanceTaskGraphFromTypeBindingTaskKindExpandCommand
+                          .context.taskKind.binding,
+                      requestId:
+                        createInstanceTaskGraphFromTypeBindingTaskKindExpandCommand
+                          .context.taskKind.requestId,
+                      type: TaskKindType.getCachedInstance,
+                    },
+                    containerRequestServiceFixture,
+                    containerSingletonServiceFixture,
+                  ),
+                },
+                expect.any(
+                  CreateInstanceTaskLazyNode,
+                ) as CreateInstanceTaskLazyNode,
+              ],
+              type: cuaktask.NodeDependenciesType.bitwiseOr,
+            },
+            element: new DestructureOneTask({
+              requestId:
+                createInstanceTaskGraphFromTypeBindingTaskKindExpandCommand
+                  .context.taskKind.requestId,
+              type: TaskKindType.destructureOne,
+            }),
           });
         });
       });

--- a/packages/iocuak/src/createInstanceTask/modules/cuaktask/BaseCreateCreateCachedScopedInstanceTaskGraphNodeCommandHandler.ts
+++ b/packages/iocuak/src/createInstanceTask/modules/cuaktask/BaseCreateCreateCachedScopedInstanceTaskGraphNodeCommandHandler.ts
@@ -9,6 +9,7 @@ import { CreateCreateInstanceTaskGraphNodeCommand } from '../../models/cuaktask/
 import { CreateInstanceTask } from '../../models/cuaktask/CreateInstanceTask';
 import { CreateInstanceTaskGraphExpandOperationContext } from '../../models/cuaktask/CreateInstanceTaskGraphExpandOperationContext';
 import { CreateInstanceTaskGraphFromTaskKindExpandOperationContext } from '../../models/cuaktask/CreateInstanceTaskGraphFromTaskKindExpandOperationContext';
+import { DestructureOneTask } from '../../models/cuaktask/DestructureOneTask';
 import { GetCachedInstanceTask } from '../../models/cuaktask/GetCachedInstanceTask';
 import { TaskGraphExpandCommand } from '../../models/cuaktask/TaskGraphExpandCommand';
 import { CreateInstanceTaskKind } from '../../models/domain/CreateInstanceTaskKind';
@@ -75,7 +76,15 @@ export abstract class BaseCreateCreateCachedScopedInstanceTaskGraphNodeCommandHa
       type: cuaktask.NodeDependenciesType.bitwiseOr,
     };
 
-    return createInstanceTaskKindGraphDependency;
+    const destructureNode: cuaktask.Node<cuaktask.Task<TaskKind>> = {
+      dependencies: createInstanceTaskKindGraphDependency,
+      element: new DestructureOneTask({
+        requestId: context.taskKind.requestId,
+        type: TaskKindType.destructureOne,
+      }),
+    };
+
+    return destructureNode;
   }
 
   // eslint-disable-next-line @typescript-eslint/member-ordering


### PR DESCRIPTION
### Changed
- Updated `DestructureOneTask` to return input.
- Updated `BaseCreateCreateCachedScopedInstanceTaskGraphNodeCommandHandler.#createNewCreateCachedScopedInstanceTaskKindGraphDependency` to return a destructured node.