### PR TITLE
Add ClassElementMetadataApi

### DIFF
--- a/packages/iocuak/src/classMetadata/models/api/BaseClassElementMetadataApi.ts
+++ b/packages/iocuak/src/classMetadata/models/api/BaseClassElementMetadataApi.ts
@@ -1,0 +1,7 @@
+import { ClassElementMetadatApiType } from './ClassElementMetadatApiType';
+
+export interface BaseClassElementMetadataApi<
+  TType extends ClassElementMetadatApiType,
+> {
+  type: TType;
+}

--- a/packages/iocuak/src/classMetadata/models/api/ClassElementMetadatApiType.ts
+++ b/packages/iocuak/src/classMetadata/models/api/ClassElementMetadatApiType.ts
@@ -1,0 +1,4 @@
+export enum ClassElementMetadatApiType {
+  serviceId = 'serviceId',
+  tag = 'tag',
+}

--- a/packages/iocuak/src/classMetadata/models/api/ClassElementMetadataApi.ts
+++ b/packages/iocuak/src/classMetadata/models/api/ClassElementMetadataApi.ts
@@ -1,0 +1,6 @@
+import { ClassElementServiceIdMetadataApi } from './ClassElementServiceIdMetadataApi';
+import { ClassElementTagMetadataApi } from './ClassElementTagMetadataApi';
+
+export type ClassElementMetadataApi =
+  | ClassElementServiceIdMetadataApi
+  | ClassElementTagMetadataApi;

--- a/packages/iocuak/src/classMetadata/models/api/ClassElementServiceIdMetadataApi.ts
+++ b/packages/iocuak/src/classMetadata/models/api/ClassElementServiceIdMetadataApi.ts
@@ -1,0 +1,8 @@
+import { ServiceId } from '../../../common/models/domain/ServiceId';
+import { BaseClassElementMetadataApi } from './BaseClassElementMetadataApi';
+import { ClassElementMetadatApiType } from './ClassElementMetadatApiType';
+
+export interface ClassElementServiceIdMetadataApi
+  extends BaseClassElementMetadataApi<ClassElementMetadatApiType.serviceId> {
+  value: ServiceId;
+}

--- a/packages/iocuak/src/classMetadata/models/api/ClassElementTagMetadataApi.ts
+++ b/packages/iocuak/src/classMetadata/models/api/ClassElementTagMetadataApi.ts
@@ -1,0 +1,8 @@
+import { BindingTag } from '../../../binding/models/domain/BindingTag';
+import { BaseClassElementMetadataApi } from './BaseClassElementMetadataApi';
+import { ClassElementMetadatApiType } from './ClassElementMetadatApiType';
+
+export interface ClassElementTagMetadataApi
+  extends BaseClassElementMetadataApi<ClassElementMetadatApiType.tag> {
+  value: BindingTag;
+}

--- a/packages/iocuak/src/classMetadata/models/domain/BaseClassElementMetadata.ts
+++ b/packages/iocuak/src/classMetadata/models/domain/BaseClassElementMetadata.ts
@@ -1,6 +1,6 @@
 import { ClassElementMetadataType } from './ClassElementMetadataType';
 
-export interface ClassElementMetadataBase<
+export interface BaseClassElementMetadata<
   TType extends ClassElementMetadataType,
 > {
   type: TType;

--- a/packages/iocuak/src/classMetadata/models/domain/ClassElementServiceIdMetadata.ts
+++ b/packages/iocuak/src/classMetadata/models/domain/ClassElementServiceIdMetadata.ts
@@ -1,8 +1,8 @@
 import { ServiceId } from '../../../common/models/domain/ServiceId';
-import { ClassElementMetadataBase } from './ClassElementMetadataBase';
+import { BaseClassElementMetadata } from './BaseClassElementMetadata';
 import { ClassElementMetadataType } from './ClassElementMetadataType';
 
 export interface ClassElementServiceIdMetadata
-  extends ClassElementMetadataBase<ClassElementMetadataType.serviceId> {
+  extends BaseClassElementMetadata<ClassElementMetadataType.serviceId> {
   value: ServiceId;
 }

--- a/packages/iocuak/src/classMetadata/models/domain/ClassElementTagMetadata.ts
+++ b/packages/iocuak/src/classMetadata/models/domain/ClassElementTagMetadata.ts
@@ -1,8 +1,8 @@
 import { BindingTag } from '../../../binding/models/domain/BindingTag';
-import { ClassElementMetadataBase } from './ClassElementMetadataBase';
+import { BaseClassElementMetadata } from './BaseClassElementMetadata';
 import { ClassElementMetadataType } from './ClassElementMetadataType';
 
 export interface ClassElementTagMetadata
-  extends ClassElementMetadataBase<ClassElementMetadataType.tag> {
+  extends BaseClassElementMetadata<ClassElementMetadataType.tag> {
   value: BindingTag;
 }


### PR DESCRIPTION
### Added
- IOC-52: Added `ClassElementMetadataTypeApi`.
- IOC-53: Added `BaseClassElementMetadataApi`.
- IOC-54: Added `ClassElementServiceIdMetadataApi`.
- IOC-55: Added `ClassElementTagMetadataApi`.
- IOC-56: Added `ClassElementMetadataApi`.