### PR TITLE
Update class metadata to with class element metadata based fields

### DIFF
--- a/packages/iocuak/src/classMetadata/decorators/inject.int.spec.ts
+++ b/packages/iocuak/src/classMetadata/decorators/inject.int.spec.ts
@@ -5,6 +5,7 @@ import { ClassMetadata } from '../../classMetadata/models/domain/ClassMetadata';
 import { Newable } from '../../common/models/domain/Newable';
 import { ServiceId } from '../../common/models/domain/ServiceId';
 import { MetadataKey } from '../../reflectMetadata/models/domain/MetadataKey';
+import { ClassElementMetadataType } from '../models/domain/ClassElementMetadataType';
 
 describe(inject.name, () => {
   describe('when called, as property decorator', () => {
@@ -32,7 +33,15 @@ describe(inject.name, () => {
     it('should set reflect metadata', () => {
       expect(reflectMetadata).toStrictEqual<ClassMetadata>({
         constructorArguments: [],
-        properties: new Map([['foo', serviceIdFixture]]),
+        properties: new Map([
+          [
+            'foo',
+            {
+              type: ClassElementMetadataType.serviceId,
+              value: serviceIdFixture,
+            },
+          ],
+        ]),
       });
     });
   });
@@ -60,7 +69,12 @@ describe(inject.name, () => {
 
     it('should set reflect metadata', () => {
       expect(reflectMetadata).toStrictEqual<ClassMetadata>({
-        constructorArguments: [serviceIdFixture],
+        constructorArguments: [
+          {
+            type: ClassElementMetadataType.serviceId,
+            value: serviceIdFixture,
+          },
+        ],
         properties: new Map(),
       });
     });

--- a/packages/iocuak/src/classMetadata/decorators/inject.ts
+++ b/packages/iocuak/src/classMetadata/decorators/inject.ts
@@ -1,6 +1,8 @@
 import { ServiceId } from '../../common/models/domain/ServiceId';
 import { MetadataKey } from '../../reflectMetadata/models/domain/MetadataKey';
 import { updateReflectMetadata } from '../../reflectMetadata/utils/domain/updateReflectMetadata';
+import { ClassElementMetadataType } from '../models/domain/ClassElementMetadataType';
+import { ClassElementServiceIdMetadata } from '../models/domain/ClassElementServiceIdMetadata';
 import { ClassMetadata } from '../models/domain/ClassMetadata';
 import { getDefaultClassMetadata } from '../utils/domain/getDefaultClassMetadata';
 
@@ -36,7 +38,8 @@ function injectParameter(serviceId: ServiceId): ParameterDecorator {
         MetadataKey.inject,
         getDefaultClassMetadata(),
         (classMetadata: ClassMetadata): ClassMetadata => {
-          classMetadata.constructorArguments[parameterIndex] = serviceId;
+          classMetadata.constructorArguments[parameterIndex] =
+            serviceIdToClassElementMatadata(serviceId);
 
           return classMetadata;
         },
@@ -60,7 +63,10 @@ function injectProperty(serviceId: ServiceId): PropertyDecorator {
       MetadataKey.inject,
       getDefaultClassMetadata(),
       (classMetadata: ClassMetadata): ClassMetadata => {
-        classMetadata.properties.set(propertyKey, serviceId);
+        classMetadata.properties.set(
+          propertyKey,
+          serviceIdToClassElementMatadata(serviceId),
+        );
 
         return classMetadata;
       },
@@ -73,4 +79,13 @@ function isConstructorParameter(
   propertyKey: string | symbol | undefined,
 ): boolean {
   return typeof target === 'function' && propertyKey === undefined;
+}
+
+function serviceIdToClassElementMatadata(
+  serviceId: ServiceId,
+): ClassElementServiceIdMetadata {
+  return {
+    type: ClassElementMetadataType.serviceId,
+    value: serviceId,
+  };
 }

--- a/packages/iocuak/src/classMetadata/decorators/injectFrom.int.spec.ts
+++ b/packages/iocuak/src/classMetadata/decorators/injectFrom.int.spec.ts
@@ -8,6 +8,8 @@ import { Newable } from '../../common/models/domain/Newable';
 import { ServiceId } from '../../common/models/domain/ServiceId';
 import { MetadataKey } from '../../reflectMetadata/models/domain/MetadataKey';
 import { getReflectMetadata } from '../../reflectMetadata/utils/domain/getReflectMetadata';
+import { ClassElementMetadata } from '../models/domain/ClassElementMetadata';
+import { ClassElementMetadataType } from '../models/domain/ClassElementMetadataType';
 
 describe(injectFrom.name, () => {
   describe('having a ClassMetadataExtensionApi with extendConstructorArguments false and extendProperties false', () => {
@@ -49,9 +51,15 @@ describe(injectFrom.name, () => {
     });
 
     describe('when called, having a source type with no metadata and a destination type with metadata', () => {
+      let constructorArgumentServiceId: ServiceId;
+      let propertyServiceId: ServiceId;
+
       let destinationType: Newable;
 
       beforeAll(() => {
+        constructorArgumentServiceId = 'sample-param';
+        propertyServiceId = 'sample-service';
+
         const baseType: Newable = class {};
 
         @injectFrom({
@@ -60,11 +68,11 @@ describe(injectFrom.name, () => {
           type: baseType,
         })
         class DestinationType {
-          @inject('sample-service')
+          @inject(propertyServiceId)
           public foo: unknown;
 
           constructor(
-            @inject('sample-param')
+            @inject(constructorArgumentServiceId)
             public readonly fooParam: unknown,
           ) {}
         }
@@ -81,8 +89,21 @@ describe(injectFrom.name, () => {
 
         it('should return metadata', () => {
           expect(result).toStrictEqual<ClassMetadata>({
-            constructorArguments: ['sample-param'],
-            properties: new Map([['foo', 'sample-service']]),
+            constructorArguments: [
+              {
+                type: ClassElementMetadataType.serviceId,
+                value: constructorArgumentServiceId,
+              },
+            ],
+            properties: new Map([
+              [
+                'foo',
+                {
+                  type: ClassElementMetadataType.serviceId,
+                  value: propertyServiceId,
+                },
+              ],
+            ]),
           });
         });
       });
@@ -181,17 +202,33 @@ describe(injectFrom.name, () => {
           });
 
           it('should return metadata', () => {
-            const expectedConstructorArguments: ServiceId[] =
-              new Array<ServiceId>(3);
+            const expectedConstructorArguments: ClassElementMetadata[] =
+              new Array<ClassElementMetadata>(3);
 
-            expectedConstructorArguments[1] = 'barParam-param-child';
-            expectedConstructorArguments[2] = 'bazParam-param-child';
+            expectedConstructorArguments[1] = {
+              type: ClassElementMetadataType.serviceId,
+              value: 'barParam-param-child',
+            };
+            expectedConstructorArguments[2] = {
+              type: ClassElementMetadataType.serviceId,
+              value: 'bazParam-param-child',
+            };
+
+            const expectedBarPropertyMetadata: ClassElementMetadata = {
+              type: ClassElementMetadataType.serviceId,
+              value: 'bar-property-child',
+            };
+
+            const expectedBazPropertyMetadata: ClassElementMetadata = {
+              type: ClassElementMetadataType.serviceId,
+              value: 'baz-property-child',
+            };
 
             expect(result).toStrictEqual<ClassMetadata>({
               constructorArguments: expectedConstructorArguments,
               properties: new Map([
-                ['bar', 'bar-property-child'],
-                ['baz', 'baz-property-child'],
+                ['bar', expectedBarPropertyMetadata],
+                ['baz', expectedBazPropertyMetadata],
               ]),
             });
           });
@@ -271,8 +308,21 @@ describe(injectFrom.name, () => {
 
         it('should return metadata', () => {
           expect(result).toStrictEqual<ClassMetadata>({
-            constructorArguments: ['sample-param'],
-            properties: new Map([['foo', 'sample-service']]),
+            constructorArguments: [
+              {
+                type: ClassElementMetadataType.serviceId,
+                value: 'sample-param',
+              },
+            ],
+            properties: new Map([
+              [
+                'foo',
+                {
+                  type: ClassElementMetadataType.serviceId,
+                  value: 'sample-service',
+                },
+              ],
+            ]),
           });
         });
       });
@@ -313,8 +363,21 @@ describe(injectFrom.name, () => {
 
         it('should return metadata', () => {
           expect(result).toStrictEqual<ClassMetadata>({
-            constructorArguments: ['sample-param'],
-            properties: new Map([['foo', 'sample-service']]),
+            constructorArguments: [
+              {
+                type: ClassElementMetadataType.serviceId,
+                value: 'sample-param',
+              },
+            ],
+            properties: new Map([
+              [
+                'foo',
+                {
+                  type: ClassElementMetadataType.serviceId,
+                  value: 'sample-service',
+                },
+              ],
+            ]),
           });
         });
       });
@@ -375,14 +438,41 @@ describe(injectFrom.name, () => {
         it('should return metadata', () => {
           expect(result).toStrictEqual<ClassMetadata>({
             constructorArguments: [
-              'fooParam-param-base',
-              'barParam-param-child',
-              'bazParam-param-child',
+              {
+                type: ClassElementMetadataType.serviceId,
+                value: 'fooParam-param-base',
+              },
+              {
+                type: ClassElementMetadataType.serviceId,
+                value: 'barParam-param-child',
+              },
+              {
+                type: ClassElementMetadataType.serviceId,
+                value: 'bazParam-param-child',
+              },
             ],
             properties: new Map([
-              ['foo', 'foo-property-base'],
-              ['bar', 'bar-property-child'],
-              ['baz', 'baz-property-child'],
+              [
+                'foo',
+                {
+                  type: ClassElementMetadataType.serviceId,
+                  value: 'foo-property-base',
+                },
+              ],
+              [
+                'bar',
+                {
+                  type: ClassElementMetadataType.serviceId,
+                  value: 'bar-property-child',
+                },
+              ],
+              [
+                'baz',
+                {
+                  type: ClassElementMetadataType.serviceId,
+                  value: 'baz-property-child',
+                },
+              ],
             ]),
           });
         });

--- a/packages/iocuak/src/classMetadata/decorators/injectFrom.ts
+++ b/packages/iocuak/src/classMetadata/decorators/injectFrom.ts
@@ -1,9 +1,9 @@
-import { ServiceId } from '../../common/models/domain/ServiceId';
 import { chain } from '../../common/utils/chain';
 import { MetadataKey } from '../../reflectMetadata/models/domain/MetadataKey';
 import { getReflectMetadata } from '../../reflectMetadata/utils/domain/getReflectMetadata';
 import { updateReflectMetadata } from '../../reflectMetadata/utils/domain/updateReflectMetadata';
 import { ClassMetadataExtensionApi } from '../models/api/ClassMetadataExtensionApi';
+import { ClassElementMetadata } from '../models/domain/ClassElementMetadata';
 import { ClassMetadata } from '../models/domain/ClassMetadata';
 import { getDefaultClassMetadata } from '../utils/domain/getDefaultClassMetadata';
 
@@ -61,11 +61,11 @@ function getExtendedConstructorArguments(
   classMetadataExtensionApi: ClassMetadataExtensionApi,
   baseTypeClassMetadata: ClassMetadata,
   typeMetadata: ClassMetadata,
-): ServiceId[] {
+): ClassElementMetadata[] {
   const extendConstructorArguments: boolean =
     classMetadataExtensionApi.extendConstructorArguments ?? false;
 
-  let extendedConstructorArguments: ServiceId[];
+  let extendedConstructorArguments: ClassElementMetadata[];
 
   if (extendConstructorArguments) {
     extendedConstructorArguments = [
@@ -73,8 +73,8 @@ function getExtendedConstructorArguments(
     ];
 
     typeMetadata.constructorArguments.map(
-      (serviceId: ServiceId, index: number) => {
-        extendedConstructorArguments[index] = serviceId;
+      (classElementMetadata: ClassElementMetadata, index: number) => {
+        extendedConstructorArguments[index] = classElementMetadata;
       },
     );
   } else {
@@ -88,11 +88,11 @@ function getExtendedProperties(
   classMetadataExtensionApi: ClassMetadataExtensionApi,
   baseTypeClassMetadata: ClassMetadata,
   typeMetadata: ClassMetadata,
-): Map<string | symbol, ServiceId> {
+): Map<string | symbol, ClassElementMetadata> {
   const extendProperties: boolean =
     classMetadataExtensionApi.extendProperties ?? false;
 
-  let extendedProperties: Map<string | symbol, ServiceId>;
+  let extendedProperties: Map<string | symbol, ClassElementMetadata>;
 
   if (extendProperties) {
     extendedProperties = new Map(

--- a/packages/iocuak/src/classMetadata/fixtures/domain/ClassMetadataFixtures.ts
+++ b/packages/iocuak/src/classMetadata/fixtures/domain/ClassMetadataFixtures.ts
@@ -1,3 +1,4 @@
+import { ClassElementMetadataType } from '../../models/domain/ClassElementMetadataType';
 import { ClassMetadata } from '../../models/domain/ClassMetadata';
 
 export class ClassMetadataFixtures {
@@ -10,31 +11,35 @@ export class ClassMetadataFixtures {
     return fixture;
   }
 
-  public static get withConstructorArgumentsAndProperties(): ClassMetadata {
+  public static get withConstructorArgumentsServiceAndPropertiesService(): ClassMetadata {
     const fixture: ClassMetadata = {
-      constructorArguments: ['sample-constructor-dependency-id'],
+      constructorArguments: [
+        {
+          type: ClassElementMetadataType.serviceId,
+          value: 'sample-constructor-dependency-id',
+        },
+      ],
       properties: new Map([
-        ['sampleProperty', 'sample-property-dependency-id'],
+        [
+          'sampleProperty',
+          {
+            type: ClassElementMetadataType.serviceId,
+            value: 'sample-property-dependency-id',
+          },
+        ],
       ]),
     };
 
     return fixture;
   }
 
-  public static get withConstructorArgumentsOneAndPropertiesEmpty(): ClassMetadata {
-    const fixture: ClassMetadata = {
-      constructorArguments: ['sample-constructor-dependency-id'],
-      properties: new Map(),
-    };
-
-    return fixture;
-  }
-
-  public static get withConstructorArgumentsTheSameTwoAndPropertiesEmpty(): ClassMetadata {
+  public static get withConstructorArgumentsOneServiceAndPropertiesEmpty(): ClassMetadata {
     const fixture: ClassMetadata = {
       constructorArguments: [
-        'sample-constructor-dependency-id',
-        'sample-constructor-dependency-id',
+        {
+          type: ClassElementMetadataType.serviceId,
+          value: 'sample-constructor-dependency-id',
+        },
       ],
       properties: new Map(),
     };
@@ -42,11 +47,17 @@ export class ClassMetadataFixtures {
     return fixture;
   }
 
-  public static get withConstructorArgumentsEmptyAndPropertiesOne(): ClassMetadata {
+  public static get withConstructorArgumentsEmptyAndPropertiesOneService(): ClassMetadata {
     const fixture: ClassMetadata = {
       constructorArguments: [],
       properties: new Map([
-        ['sampleProperty', 'sample-property-dependency-id'],
+        [
+          'sampleProperty',
+          {
+            type: ClassElementMetadataType.serviceId,
+            value: 'sample-property-dependency-id',
+          },
+        ],
       ]),
     };
 

--- a/packages/iocuak/src/classMetadata/fixtures/domain/ClassMetadataFixtures.ts
+++ b/packages/iocuak/src/classMetadata/fixtures/domain/ClassMetadataFixtures.ts
@@ -47,6 +47,20 @@ export class ClassMetadataFixtures {
     return fixture;
   }
 
+  public static get withConstructorArgumentsOneTagAndPropertiesEmpty(): ClassMetadata {
+    const fixture: ClassMetadata = {
+      constructorArguments: [
+        {
+          type: ClassElementMetadataType.tag,
+          value: Symbol(),
+        },
+      ],
+      properties: new Map(),
+    };
+
+    return fixture;
+  }
+
   public static get withConstructorArgumentsEmptyAndPropertiesOneService(): ClassMetadata {
     const fixture: ClassMetadata = {
       constructorArguments: [],

--- a/packages/iocuak/src/classMetadata/models/domain/ClassMetadata.ts
+++ b/packages/iocuak/src/classMetadata/models/domain/ClassMetadata.ts
@@ -1,6 +1,6 @@
-import { ServiceId } from '../../../common/models/domain/ServiceId';
+import { ClassElementMetadata } from './ClassElementMetadata';
 
 export interface ClassMetadata {
-  constructorArguments: ServiceId[];
-  properties: Map<string | symbol, ServiceId>;
+  constructorArguments: ClassElementMetadata[];
+  properties: Map<string | symbol, ClassElementMetadata>;
 }

--- a/packages/iocuak/src/classMetadata/utils/api/convertToClassMetadataApi.spec.ts
+++ b/packages/iocuak/src/classMetadata/utils/api/convertToClassMetadataApi.spec.ts
@@ -1,5 +1,6 @@
 import { ClassElementMetadatApiType } from '../../models/api/ClassElementMetadatApiType';
 import { ClassMetadataApi } from '../../models/api/ClassMetadataApi';
+import { ClassElementMetadataType } from '../../models/domain/ClassElementMetadataType';
 import { ClassMetadata } from '../../models/domain/ClassMetadata';
 import { convertToClassMetadataApi } from './convertToClassMetadataApi';
 
@@ -11,8 +12,21 @@ describe(convertToClassMetadataApi.name, () => {
 
     beforeAll(() => {
       classMetadataFixture = {
-        constructorArguments: ['ctor-first-service-id'],
-        properties: new Map([['foo', Symbol.for('bar')]]),
+        constructorArguments: [
+          {
+            type: ClassElementMetadataType.serviceId,
+            value: 'ctor-first-service-id',
+          },
+        ],
+        properties: new Map([
+          [
+            'foo',
+            {
+              type: ClassElementMetadataType.serviceId,
+              value: Symbol.for('bar'),
+            },
+          ],
+        ]),
       };
 
       classMetadataApiFixture = {

--- a/packages/iocuak/src/classMetadata/utils/api/convertToClassMetadataApi.ts
+++ b/packages/iocuak/src/classMetadata/utils/api/convertToClassMetadataApi.ts
@@ -1,24 +1,30 @@
-import { ServiceId } from '../../../common/models/domain/ServiceId';
 import { mapIterable } from '../../../common/utils/mapIterable';
 import { ClassElementMetadataApi } from '../../models/api/ClassElementMetadataApi';
 import { ClassElementMetadatApiType } from '../../models/api/ClassElementMetadatApiType';
 import { ClassMetadataApi } from '../../models/api/ClassMetadataApi';
+import { ClassElementMetadata } from '../../models/domain/ClassElementMetadata';
+import { ClassElementMetadataType } from '../../models/domain/ClassElementMetadataType';
 import { ClassMetadata } from '../../models/domain/ClassMetadata';
 
 export function convertToClassMetadataApi(
   classMetadata: ClassMetadata,
 ): ClassMetadataApi {
   const classMetadataApiConstructorArguments: ClassElementMetadataApi[] =
-    classMetadata.constructorArguments.map(serviceIdToClassMetadataApi);
+    classMetadata.constructorArguments.map(
+      classElementMetadataToClassElementMetadataApi,
+    );
   const classMetadataApiProperties: Map<
     string | symbol,
     ClassElementMetadataApi
   > = new Map(
     mapIterable(
       classMetadata.properties.entries(),
-      ([key, serviceId]: [string | symbol, ServiceId]) => [
+      ([key, classElementMetadata]: [
+        string | symbol,
+        ClassElementMetadata,
+      ]) => [
         key,
-        serviceIdToClassMetadataApi(serviceId),
+        classElementMetadataToClassElementMetadataApi(classElementMetadata),
       ],
     ),
   );
@@ -29,11 +35,19 @@ export function convertToClassMetadataApi(
   };
 }
 
-function serviceIdToClassMetadataApi(
-  serviceId: ServiceId,
+function classElementMetadataToClassElementMetadataApi(
+  classElementMetadata: ClassElementMetadata,
 ): ClassElementMetadataApi {
-  return {
-    type: ClassElementMetadatApiType.serviceId,
-    value: serviceId,
-  };
+  switch (classElementMetadata.type) {
+    case ClassElementMetadataType.serviceId:
+      return {
+        type: ClassElementMetadatApiType.serviceId,
+        value: classElementMetadata.value,
+      };
+    case ClassElementMetadataType.tag:
+      return {
+        type: ClassElementMetadatApiType.tag,
+        value: classElementMetadata.value,
+      };
+  }
 }

--- a/packages/iocuak/src/createInstanceTask/fixtures/domain/GetInstanceDependenciesTaskKindFixtures.ts
+++ b/packages/iocuak/src/createInstanceTask/fixtures/domain/GetInstanceDependenciesTaskKindFixtures.ts
@@ -16,7 +16,8 @@ export class GetInstanceDependenciesTaskKindFixtures {
   public static get withMetadataWithConstructorArgumentsAndProperties(): GetInstanceDependenciesTaskKind {
     const fixture: GetInstanceDependenciesTaskKind = {
       ...GetInstanceDependenciesTaskKindFixtures.any,
-      metadata: ClassMetadataFixtures.withConstructorArgumentsAndProperties,
+      metadata:
+        ClassMetadataFixtures.withConstructorArgumentsServiceAndPropertiesService,
     };
 
     return fixture;
@@ -36,7 +37,7 @@ export class GetInstanceDependenciesTaskKindFixtures {
     const fixture: GetInstanceDependenciesTaskKind = {
       ...GetInstanceDependenciesTaskKindFixtures.any,
       metadata:
-        ClassMetadataFixtures.withConstructorArgumentsEmptyAndPropertiesOne,
+        ClassMetadataFixtures.withConstructorArgumentsEmptyAndPropertiesOneService,
     };
 
     return fixture;
@@ -46,7 +47,7 @@ export class GetInstanceDependenciesTaskKindFixtures {
     const fixture: GetInstanceDependenciesTaskKind = {
       ...GetInstanceDependenciesTaskKindFixtures.any,
       metadata:
-        ClassMetadataFixtures.withConstructorArgumentsOneAndPropertiesEmpty,
+        ClassMetadataFixtures.withConstructorArgumentsOneServiceAndPropertiesEmpty,
     };
 
     return fixture;

--- a/packages/iocuak/src/createInstanceTask/fixtures/domain/GetInstanceDependenciesTaskKindFixtures.ts
+++ b/packages/iocuak/src/createInstanceTask/fixtures/domain/GetInstanceDependenciesTaskKindFixtures.ts
@@ -43,11 +43,21 @@ export class GetInstanceDependenciesTaskKindFixtures {
     return fixture;
   }
 
-  public static get withMetadataWithConstructorArgumentsOneAndPropertiesEmpty(): GetInstanceDependenciesTaskKind {
+  public static get withMetadataWithConstructorArgumentsOneServiceAndPropertiesEmpty(): GetInstanceDependenciesTaskKind {
     const fixture: GetInstanceDependenciesTaskKind = {
       ...GetInstanceDependenciesTaskKindFixtures.any,
       metadata:
         ClassMetadataFixtures.withConstructorArgumentsOneServiceAndPropertiesEmpty,
+    };
+
+    return fixture;
+  }
+
+  public static get withMetadataWithConstructorArgumentsOneTagAndPropertiesEmpty(): GetInstanceDependenciesTaskKind {
+    const fixture: GetInstanceDependenciesTaskKind = {
+      ...GetInstanceDependenciesTaskKindFixtures.any,
+      metadata:
+        ClassMetadataFixtures.withConstructorArgumentsOneTagAndPropertiesEmpty,
     };
 
     return fixture;

--- a/packages/iocuak/src/createInstanceTask/modules/cuaktask/GetInstanceDependenciesTaskGraphExpandCommandHandler.spec.ts
+++ b/packages/iocuak/src/createInstanceTask/modules/cuaktask/GetInstanceDependenciesTaskGraphExpandCommandHandler.spec.ts
@@ -1,4 +1,6 @@
 import * as cuaktask from '@cuaklabs/cuaktask';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import * as jestMock from 'jest-mock';
 
 import { TypeBindingFixtures } from '../../../binding/fixtures/domain/TypeBindingFixtures';
 import { ValueBindingFixtures } from '../../../binding/fixtures/domain/ValueBindingFixtures';
@@ -20,10 +22,10 @@ import { TaskKindType } from '../../models/domain/TaskKindType';
 import { GetInstanceDependenciesTaskGraphExpandCommandHandler } from './GetInstanceDependenciesTaskGraphExpandCommandHandler';
 
 describe(GetInstanceDependenciesTaskGraphExpandCommandHandler.name, () => {
-  let bindingServiceMock: jest.Mocked<BindingService>;
+  let bindingServiceMock: jestMock.Mocked<BindingService>;
   let containerRequestServiceFixture: ContainerRequestService;
   let containerSingletonServiceFixture: ContainerSingletonService;
-  let createCreateInstanceTaskGraphNodeCommandHandlerMock: jest.Mocked<
+  let createCreateInstanceTaskGraphNodeCommandHandlerMock: jestMock.Mocked<
     Handler<
       CreateCreateInstanceTaskGraphNodeCommand,
       cuaktask.NodeDependency<cuaktask.Task<TaskKind>>
@@ -36,7 +38,10 @@ describe(GetInstanceDependenciesTaskGraphExpandCommandHandler.name, () => {
   beforeAll(() => {
     bindingServiceMock = {
       get: jest.fn(),
-    } as Partial<jest.Mocked<BindingService>> as jest.Mocked<BindingService>;
+      getByTag: jest.fn(),
+    } as Partial<
+      jestMock.Mocked<BindingService>
+    > as jestMock.Mocked<BindingService>;
     containerRequestServiceFixture = {
       _type: Symbol(),
     } as unknown as ContainerRequestService;
@@ -61,7 +66,7 @@ describe(GetInstanceDependenciesTaskGraphExpandCommandHandler.name, () => {
   });
 
   describe('.handle', () => {
-    describe('having a Node fixture', () => {
+    describe('having a Node fixture with service metadata', () => {
       let nodeFixture: cuaktask.Node<
         cuaktask.Task<GetInstanceDependenciesTaskKind>
       >;
@@ -70,13 +75,16 @@ describe(GetInstanceDependenciesTaskGraphExpandCommandHandler.name, () => {
         nodeFixture = {
           dependencies: undefined,
           element: new GetInstanceDependenciesTask(
-            GetInstanceDependenciesTaskKindFixtures.withMetadataWithConstructorArgumentsOneAndPropertiesEmpty,
+            GetInstanceDependenciesTaskKindFixtures.withMetadataWithConstructorArgumentsOneServiceAndPropertiesEmpty,
           ),
         };
       });
 
-      describe('when called, and bindingService returns a ValueBinding', () => {
+      describe('when called, and bindingService.get() returns a ValueBinding', () => {
         let getInstanceDependenciesTaskGraphExpandCommandFixture: GetInstanceDependenciesTaskGraphExpandCommand;
+        let expectedCreateInstanceNodeGenerated: cuaktask.Node<
+          cuaktask.Task<TaskKind>
+        >;
 
         let result: unknown;
 
@@ -93,6 +101,21 @@ describe(GetInstanceDependenciesTaskGraphExpandCommandHandler.name, () => {
             },
             node: nodeFixture,
             taskKindType: TaskGraphExpandCommandType.getInstanceDependencies,
+          };
+
+          expectedCreateInstanceNodeGenerated = {
+            dependencies: undefined,
+            element: new CreateInstanceTask(
+              {
+                binding: ValueBindingFixtures.any,
+                requestId:
+                  getInstanceDependenciesTaskGraphExpandCommandFixture.context
+                    .requestId,
+                type: TaskKindType.createInstance,
+              },
+              containerRequestServiceFixture,
+              containerSingletonServiceFixture,
+            ),
           };
 
           bindingServiceMock.get.mockReturnValueOnce(ValueBindingFixtures.any);
@@ -118,22 +141,22 @@ describe(GetInstanceDependenciesTaskGraphExpandCommandHandler.name, () => {
             getInstanceDependenciesTaskGraphExpandCommandFixture.context.graph,
           ).toStrictEqual({
             nodes: new Set<cuaktask.Node<cuaktask.Task<TaskKind>>>([
-              {
-                dependencies: undefined,
-                element: new CreateInstanceTask(
-                  {
-                    binding: ValueBindingFixtures.any,
-                    requestId:
-                      getInstanceDependenciesTaskGraphExpandCommandFixture
-                        .context.requestId,
-                    type: TaskKindType.createInstance,
-                  },
-                  containerRequestServiceFixture,
-                  containerSingletonServiceFixture,
-                ),
-              },
+              expectedCreateInstanceNodeGenerated,
             ]),
           });
+        });
+
+        it('should set node dependencies', () => {
+          const expectedNodeDependency: cuaktask.NodeDependency<
+            cuaktask.Task<TaskKind>
+          > = {
+            nodes: [expectedCreateInstanceNodeGenerated],
+            type: cuaktask.NodeDependenciesType.and,
+          };
+
+          expect(nodeFixture.dependencies).toStrictEqual(
+            expectedNodeDependency,
+          );
         });
 
         it('should return undefined', () => {
@@ -141,7 +164,7 @@ describe(GetInstanceDependenciesTaskGraphExpandCommandHandler.name, () => {
         });
       });
 
-      describe('when called, and bindingService returns a TypeBinding', () => {
+      describe('when called, and bindingService.get() returns a TypeBinding', () => {
         let getInstanceDependenciesTaskGraphExpandCommandFixture: GetInstanceDependenciesTaskGraphExpandCommand;
         let createInstanceTaskKindGraphNodeDependencyFixture: cuaktask.Node<
           cuaktask.Task<TaskKind>
@@ -233,6 +256,126 @@ describe(GetInstanceDependenciesTaskGraphExpandCommandHandler.name, () => {
               createInstanceTaskKindGraphNodeDependencyFixture,
             ]),
           });
+        });
+
+        it('should set node dependencies', () => {
+          const expectedNodeDependency: cuaktask.NodeDependency<
+            cuaktask.Task<TaskKind>
+          > = {
+            nodes: [createInstanceTaskKindGraphNodeDependencyFixture],
+            type: cuaktask.NodeDependenciesType.and,
+          };
+
+          expect(nodeFixture.dependencies).toStrictEqual(
+            expectedNodeDependency,
+          );
+        });
+
+        it('should return undefined', () => {
+          expect(result).toBeUndefined();
+        });
+      });
+    });
+
+    describe('having a Node fixture with tag metadata', () => {
+      let nodeFixture: cuaktask.Node<
+        cuaktask.Task<GetInstanceDependenciesTaskKind>
+      >;
+
+      beforeAll(() => {
+        nodeFixture = {
+          dependencies: undefined,
+          element: new GetInstanceDependenciesTask(
+            GetInstanceDependenciesTaskKindFixtures.withMetadataWithConstructorArgumentsOneTagAndPropertiesEmpty,
+          ),
+        };
+      });
+
+      describe('when called, and bindingService.getByTag() returns a ValueBinding', () => {
+        let getInstanceDependenciesTaskGraphExpandCommandFixture: GetInstanceDependenciesTaskGraphExpandCommand;
+        let expectedCreateInstanceNodeGenerated: cuaktask.Node<
+          cuaktask.Task<TaskKind>
+        >;
+
+        let result: unknown;
+
+        beforeAll(() => {
+          getInstanceDependenciesTaskGraphExpandCommandFixture = {
+            context: {
+              graph: {
+                nodes: new Set(),
+              },
+              requestId: Symbol(),
+              serviceIdAncestorList: ReadOnlyLinkedListImplementation.build(),
+              serviceIdToRequestCreateInstanceTaskKindNode: new Map(),
+              serviceIdToSingletonCreateInstanceTaskKindNode: new Map(),
+            },
+            node: nodeFixture,
+            taskKindType: TaskGraphExpandCommandType.getInstanceDependencies,
+          };
+
+          expectedCreateInstanceNodeGenerated = {
+            dependencies: undefined,
+            element: new CreateInstanceTask(
+              {
+                binding: ValueBindingFixtures.any,
+                requestId:
+                  getInstanceDependenciesTaskGraphExpandCommandFixture.context
+                    .requestId,
+                type: TaskKindType.createInstance,
+              },
+              containerRequestServiceFixture,
+              containerSingletonServiceFixture,
+            ),
+          };
+
+          bindingServiceMock.getByTag.mockReturnValueOnce([
+            ValueBindingFixtures.any,
+          ]);
+
+          result = getInstanceDependenciesTaskGraphExpandCommandHandler.handle(
+            getInstanceDependenciesTaskGraphExpandCommandFixture,
+          );
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call bindingService.getByTag()', () => {
+          expect(bindingServiceMock.getByTag).toHaveBeenCalledTimes(1);
+          expect(bindingServiceMock.getByTag).toHaveBeenCalledWith(
+            nodeFixture.element.kind.metadata.constructorArguments[0]?.value,
+            true,
+          );
+        });
+
+        it('should expand graph nodes', () => {
+          expect(
+            getInstanceDependenciesTaskGraphExpandCommandFixture.context.graph,
+          ).toStrictEqual({
+            nodes: new Set<cuaktask.Node<cuaktask.Task<TaskKind>>>([
+              expectedCreateInstanceNodeGenerated,
+            ]),
+          });
+        });
+
+        it('should set node dependencies', () => {
+          const expectedNodeDependency: cuaktask.NodeDependency<
+            cuaktask.Task<TaskKind>
+          > = {
+            nodes: [
+              {
+                nodes: [expectedCreateInstanceNodeGenerated],
+                type: cuaktask.NodeDependenciesType.and,
+              },
+            ],
+            type: cuaktask.NodeDependenciesType.and,
+          };
+
+          expect(nodeFixture.dependencies).toStrictEqual(
+            expectedNodeDependency,
+          );
         });
 
         it('should return undefined', () => {

--- a/packages/iocuak/src/createInstanceTask/modules/cuaktask/GetInstanceDependenciesTaskGraphExpandCommandHandler.spec.ts
+++ b/packages/iocuak/src/createInstanceTask/modules/cuaktask/GetInstanceDependenciesTaskGraphExpandCommandHandler.spec.ts
@@ -109,7 +109,7 @@ describe(GetInstanceDependenciesTaskGraphExpandCommandHandler.name, () => {
         it('should call bindingService.get()', () => {
           expect(bindingServiceMock.get).toHaveBeenCalledTimes(1);
           expect(bindingServiceMock.get).toHaveBeenCalledWith(
-            nodeFixture.element.kind.metadata.constructorArguments[0],
+            nodeFixture.element.kind.metadata.constructorArguments[0]?.value,
           );
         });
 
@@ -196,7 +196,7 @@ describe(GetInstanceDependenciesTaskGraphExpandCommandHandler.name, () => {
         it('should call bindingService.get()', () => {
           expect(bindingServiceMock.get).toHaveBeenCalledTimes(1);
           expect(bindingServiceMock.get).toHaveBeenCalledWith(
-            nodeFixture.element.kind.metadata.constructorArguments[0],
+            nodeFixture.element.kind.metadata.constructorArguments[0]?.value,
           );
         });
 

--- a/packages/iocuak/src/createInstanceTask/modules/cuaktask/GetInstanceDependenciesTaskGraphExpandCommandHandler.ts
+++ b/packages/iocuak/src/createInstanceTask/modules/cuaktask/GetInstanceDependenciesTaskGraphExpandCommandHandler.ts
@@ -124,12 +124,12 @@ export class GetInstanceDependenciesTaskGraphExpandCommandHandler
     }
   }
 
-  #createCreateInstanceTaskGraphNodeDependencyFromServiceId(
+  #createCreateInstanceTaskGraphNodeDependencyFromBinding(
     context: CreateInstanceTaskGraphExpandOperationContext,
-    serviceId: ServiceId,
+    binding: Binding,
   ): cuaktask.NodeDependency<cuaktask.Task<TaskKind>> {
     const createInstanceTaskKind: CreateInstanceTaskKind = {
-      binding: this.#getBinding(serviceId),
+      binding: binding,
       requestId: context.requestId,
       type: TaskKindType.createInstance,
     };
@@ -158,6 +158,18 @@ export class GetInstanceDependenciesTaskGraphExpandCommandHandler
     return createInstanceTaskKindGraphNodeDependency;
   }
 
+  #createCreateInstanceTaskGraphNodeDependencyFromServiceId(
+    context: CreateInstanceTaskGraphExpandOperationContext,
+    serviceId: ServiceId,
+  ): cuaktask.NodeDependency<cuaktask.Task<TaskKind>> {
+    const binding: Binding = this.#getBinding(serviceId);
+
+    return this.#createCreateInstanceTaskGraphNodeDependencyFromBinding(
+      context,
+      binding,
+    );
+  }
+
   #createCreateInstanceTaskGraphNodeDependencyFromTag(
     context: CreateInstanceTaskGraphExpandOperationContext,
     tag: BindingTag,
@@ -165,9 +177,9 @@ export class GetInstanceDependenciesTaskGraphExpandCommandHandler
     const bindings: Binding[] = [...this.#getBindings(tag)];
     const tagServiceNodes: cuaktask.NodeDependency<cuaktask.Task<TaskKind>>[] =
       bindings.map((binding: Binding) =>
-        this.#createCreateInstanceTaskGraphNodeDependencyFromServiceId(
+        this.#createCreateInstanceTaskGraphNodeDependencyFromBinding(
           context,
-          binding.id,
+          binding,
         ),
       );
 

--- a/packages/iocuak/src/metadata/services/domain/MetadataServiceImplementation.spec.ts
+++ b/packages/iocuak/src/metadata/services/domain/MetadataServiceImplementation.spec.ts
@@ -95,7 +95,7 @@ describe(MetadataServiceImplementation.name, () => {
       beforeAll(() => {
         typeFixture = class {};
         classMetadataFixture =
-          ClassMetadataFixtures.withConstructorArgumentsAndProperties;
+          ClassMetadataFixtures.withConstructorArgumentsServiceAndPropertiesService;
 
         (getReflectMetadata as jest.Mock<ClassMetadata>).mockReturnValueOnce(
           classMetadataFixture,
@@ -118,7 +118,7 @@ describe(MetadataServiceImplementation.name, () => {
 
       it('should return ClassMetadata', () => {
         expect(result).toStrictEqual(
-          ClassMetadataFixtures.withConstructorArgumentsAndProperties,
+          ClassMetadataFixtures.withConstructorArgumentsServiceAndPropertiesService,
         );
       });
     });


### PR DESCRIPTION
### Changed
- Updated `BindingServiceImplementation` to rely on `chain`.
- Update ClassMetadata with ClassElementMetadata based fields.
- Updated `ClassMetadaFixtures`.
- Updated `convertToClassMetadataApi`.
- Updated `GetInstanceDependenciesTaskGraphExpandCommandHandler` to handle `ClassElementTagMetadata`.
- Updated `GetInstanceDependenciesTaskGraphExpandCommandHandler.#createCreateInstanceTaskGraphNodeDependencyFromBinding` to avoid geting bindings twice.