### PR TITLE
Update injectable to map injectable options api tags

### DIFF
--- a/packages/iocuak/CHANGELOG.md
+++ b/packages/iocuak/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Updated `ContainerModuleMetadata` to allow module classes and modules.
+- Updated `InjectableOptions` with tags
 - [BC]: Updated `ClassMetadata` to contain `ClassElementMetadata` based properties and constructor arguments.
 
 

--- a/packages/iocuak/src/binding/decorators/injectable.spec.ts
+++ b/packages/iocuak/src/binding/decorators/injectable.spec.ts
@@ -10,6 +10,7 @@ import { TypeBindingFixtures } from '../fixtures/domain/TypeBindingFixtures';
 import { BindingScopeApi } from '../models/api/BindingScopeApi';
 import { bindingScopeApiToBindingScopeMap } from '../models/api/bindingScopeApiToBindingScopeMap';
 import { BindingScope } from '../models/domain/BindingScope';
+import { BindingTag } from '../models/domain/BindingTag';
 import { TypeBinding } from '../models/domain/TypeBinding';
 import { injectable } from './injectable';
 
@@ -121,6 +122,64 @@ describe(injectable.name, () => {
         ...TypeBindingFixtures.withTagsEmpty,
         id: targetFixture,
         scope: expectedScope,
+        type: targetFixture,
+      };
+
+      expect(reflectMetadata).toStrictEqual(expectedReflectMetadata);
+    });
+  });
+
+  describe('when called, with InjectableOptionsApi with tags array', () => {
+    let targetFixture: Newable;
+    let reflectMetadata: unknown;
+
+    beforeAll(() => {
+      @injectable(InjectableOptionsApiFixtures.withTags)
+      class TargetFixture {}
+
+      targetFixture = TargetFixture;
+
+      reflectMetadata = Reflect.getOwnMetadata(
+        MetadataKey.injectable,
+        targetFixture,
+      );
+    });
+
+    it('should set reflect metadata', () => {
+      const expectedReflectMetadata: TypeBinding = {
+        ...TypeBindingFixtures.any,
+        id: targetFixture,
+        scope: BindingScope.transient,
+        tags: InjectableOptionsApiFixtures.withTags.tags as BindingTag[],
+        type: targetFixture,
+      };
+
+      expect(reflectMetadata).toStrictEqual(expectedReflectMetadata);
+    });
+  });
+
+  describe('when called, with InjectableOptionsApi with tags tag', () => {
+    let targetFixture: Newable;
+    let reflectMetadata: unknown;
+
+    beforeAll(() => {
+      @injectable(InjectableOptionsApiFixtures.withTag)
+      class TargetFixture {}
+
+      targetFixture = TargetFixture;
+
+      reflectMetadata = Reflect.getOwnMetadata(
+        MetadataKey.injectable,
+        targetFixture,
+      );
+    });
+
+    it('should set reflect metadata', () => {
+      const expectedReflectMetadata: TypeBinding = {
+        ...TypeBindingFixtures.any,
+        id: targetFixture,
+        scope: BindingScope.transient,
+        tags: [InjectableOptionsApiFixtures.withTag.tags as BindingTag],
         type: targetFixture,
       };
 

--- a/packages/iocuak/src/binding/decorators/injectable.ts
+++ b/packages/iocuak/src/binding/decorators/injectable.ts
@@ -4,28 +4,23 @@ import { MetadataKey } from '../../reflectMetadata/models/domain/MetadataKey';
 import { bindingScopeApiToBindingScopeMap } from '../models/api/bindingScopeApiToBindingScopeMap';
 import { InjectableOptionsApi } from '../models/api/InjectableOptionsApi';
 import { BindingScope } from '../models/domain/BindingScope';
+import { BindingTag } from '../models/domain/BindingTag';
 import { BindingType } from '../models/domain/BindingType';
 import { TypeBinding } from '../models/domain/TypeBinding';
 import { getDefaultBindingScope } from '../utils/domain/getDefaultBindingScope';
 
-export function injectable(bindingApi?: InjectableOptionsApi): ClassDecorator {
+export function injectable(options?: InjectableOptionsApi): ClassDecorator {
   // eslint-disable-next-line @typescript-eslint/ban-types
   const decorator: ClassDecorator = <TFunction extends Function>(
     target: TFunction,
   ): TFunction | void => {
-    const bindingId: ServiceId =
-      bindingApi?.id ?? (target as unknown as Newable);
-
-    const bindingScope: BindingScope =
-      bindingApi?.scope === undefined
-        ? getDefaultBindingScope()
-        : bindingScopeApiToBindingScopeMap[bindingApi.scope];
+    const bindingId: ServiceId = options?.id ?? (target as unknown as Newable);
 
     const binding: TypeBinding = {
       bindingType: BindingType.type,
       id: bindingId,
-      scope: bindingScope,
-      tags: [],
+      scope: getBindingScope(options),
+      tags: getTags(options),
       type: target as unknown as Newable,
     };
 
@@ -33,4 +28,27 @@ export function injectable(bindingApi?: InjectableOptionsApi): ClassDecorator {
   };
 
   return decorator;
+}
+
+function getBindingScope(options?: InjectableOptionsApi): BindingScope {
+  const bindingScope: BindingScope =
+    options?.scope === undefined
+      ? getDefaultBindingScope()
+      : bindingScopeApiToBindingScopeMap[options.scope];
+
+  return bindingScope;
+}
+
+function getTags(options?: InjectableOptionsApi): BindingTag[] {
+  const tagOrTags: BindingTag | BindingTag[] = options?.tags ?? [];
+
+  let tags: BindingTag[];
+
+  if (Array.isArray(tagOrTags)) {
+    tags = tagOrTags;
+  } else {
+    tags = [tagOrTags];
+  }
+
+  return tags;
 }

--- a/packages/iocuak/src/binding/fixtures/api/InjectableOptionsApiFixtures.ts
+++ b/packages/iocuak/src/binding/fixtures/api/InjectableOptionsApiFixtures.ts
@@ -23,4 +23,20 @@ export class InjectableOptionsApiFixtures {
 
     return fixture;
   }
+
+  public static get withTag(): InjectableOptionsApi {
+    const fixture: InjectableOptionsApi = {
+      tags: 'tag',
+    };
+
+    return fixture;
+  }
+
+  public static get withTags(): InjectableOptionsApi {
+    const fixture: InjectableOptionsApi = {
+      tags: ['tag'],
+    };
+
+    return fixture;
+  }
 }

--- a/packages/iocuak/src/binding/models/api/InjectableOptionsApi.ts
+++ b/packages/iocuak/src/binding/models/api/InjectableOptionsApi.ts
@@ -1,7 +1,9 @@
 import { ServiceId } from '../../../common/models/domain/ServiceId';
+import { BindingTag } from '../domain/BindingTag';
 import { BindingScopeApi } from './BindingScopeApi';
 
 export interface InjectableOptionsApi {
   id?: ServiceId;
   scope?: BindingScopeApi;
+  tags?: BindingTag | BindingTag[];
 }

--- a/packages/iocuak/src/index.ts
+++ b/packages/iocuak/src/index.ts
@@ -5,6 +5,7 @@ import { BindingTypeApi } from './binding/models/api/BindingTypeApi';
 import { InjectableOptionsApi } from './binding/models/api/InjectableOptionsApi';
 import { TypeBindingApi } from './binding/models/api/TypeBindingApi';
 import { ValueBindingApi } from './binding/models/api/ValueBindingApi';
+import { BindingTag } from './binding/models/domain/BindingTag';
 import { inject } from './classMetadata/decorators/inject';
 import { injectFrom } from './classMetadata/decorators/injectFrom';
 import { injectFromBase } from './classMetadata/decorators/injectFromBase';
@@ -21,6 +22,7 @@ import { MetadataServiceApi } from './metadata/services/api/MetadataServiceApi';
 
 export type {
   BindingApi as Binding,
+  BindingTag,
   BindingTypeApi as BindingType,
   ClassMetadataApi as ClassMetadata,
   ContainerModuleMetadataApi as ContainerModuleMetadata,


### PR DESCRIPTION
### Changed
- Update index to expose `BindingTag`.
- IOC-66: Updated `injectable` to handle tags.
- IOC-65: Updated `InjectableOptionsApi` with tags.