### PR TITLE
Add create tag instances task graph expand command handler

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 pnpm exec lint-staged
-pnpm run test:previous
+pnpm run test:uncommitted

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:js:ci:coverage": "pnpm run test:js --ci --coverage",
     "test:package:js:ci": "jest --config=config/jest/jest.js.config.mjs --ci",
     "test:package:js:ci:coverage": "pnpm run test:package:js:ci --coverage",
-    "test:previous": "pnpm run test --changedSince=HEAD~1",
+    "test:uncommitted": "pnpm run test --changedSince=HEAD",
     "test:unit": "jest --config=config/jest/jest.config.mjs --selectProjects Unit",
     "test:unit:js": "jest --config=config/jest/jest.js.config.mjs --selectProjects Unit",
     "test": "jest --config=config/jest/jest.config.mjs --selectProjects Unit Integration"

--- a/packages/iocuak/src/createInstanceTask/modules/cuaktask/CreateTagInstancesTaskGraphExpandCommandHandler.spec.ts
+++ b/packages/iocuak/src/createInstanceTask/modules/cuaktask/CreateTagInstancesTaskGraphExpandCommandHandler.spec.ts
@@ -1,0 +1,177 @@
+import * as cuaktask from '@cuaklabs/cuaktask';
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import * as jestMock from 'jest-mock';
+
+jest.mock('../../utils/addNodesToGraph');
+
+import { ValueBindingFixtures } from '../../../binding/fixtures/domain/ValueBindingFixtures';
+import { BindingService } from '../../../binding/services/domain/BindingService';
+import { Handler } from '../../../common/modules/domain/Handler';
+import { ContainerRequestService } from '../../../container/services/domain/ContainerRequestService';
+import { ContainerSingletonService } from '../../../container/services/domain/ContainerSingletonService';
+import { ReadOnlyLinkedListImplementation } from '../../../list/models/domain/ReadOnlyLinkedListImplementation';
+import { CreateTagInstancesTaskKindFixtures } from '../../fixtures/domain/CreateTagInstancesTaskKindFixtures';
+import { CreateCreateInstanceTaskGraphNodeCommand } from '../../models/cuaktask/CreateCreateInstanceTaskGraphNodeCommand';
+import { CreateInstanceTask } from '../../models/cuaktask/CreateInstanceTask';
+import { CreateTagInstancesTask } from '../../models/cuaktask/CreateTagInstancesTask';
+import { CreateTagInstancesTaskGraphExpandCommand } from '../../models/cuaktask/CreateTagInstancesTaskGraphExpandCommand';
+import { TaskGraphExpandCommandType } from '../../models/cuaktask/TaskGraphExpandCommandType';
+import { CreateTagInstancesTaskKind } from '../../models/domain/CreateTagInstancesTaskKind';
+import { TaskKind } from '../../models/domain/TaskKind';
+import { TaskKindType } from '../../models/domain/TaskKindType';
+import { addNodesToGraph } from '../../utils/addNodesToGraph';
+import { CreateTagInstancesTaskGraphExpandCommandHandler } from './CreateTagInstancesTaskGraphExpandCommandHandler';
+
+describe(CreateTagInstancesTaskGraphExpandCommandHandler.name, () => {
+  let bindingServiceMock: jestMock.Mocked<BindingService>;
+  let createCreateInstanceTaskGraphNodeCommandHandlerMock: jestMock.Mocked<
+    Handler<
+      CreateCreateInstanceTaskGraphNodeCommand,
+      cuaktask.NodeDependency<cuaktask.Task<TaskKind>>
+    >
+  >;
+  let createTagInstancesTaskGraphExpandCommandHandler: CreateTagInstancesTaskGraphExpandCommandHandler;
+
+  beforeAll(() => {
+    bindingServiceMock = {
+      getByTag: jest.fn(),
+    } as Partial<
+      jestMock.Mocked<BindingService>
+    > as jestMock.Mocked<BindingService>;
+
+    createCreateInstanceTaskGraphNodeCommandHandlerMock = {
+      handle: jest.fn(),
+    };
+
+    createTagInstancesTaskGraphExpandCommandHandler =
+      new CreateTagInstancesTaskGraphExpandCommandHandler(
+        bindingServiceMock,
+        createCreateInstanceTaskGraphNodeCommandHandlerMock,
+      );
+  });
+
+  describe('.handle', () => {
+    describe('when called', () => {
+      let nodeFixture: cuaktask.Node<cuaktask.Task<CreateTagInstancesTaskKind>>;
+      let createTagInstancesTaskGraphExpandCommandFixture: CreateTagInstancesTaskGraphExpandCommand;
+      let createInstanceTaskKindGraphNodeDependencyFixture: cuaktask.Node<
+        cuaktask.Task<TaskKind>
+      >;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        nodeFixture = {
+          dependencies: undefined,
+          element: new CreateTagInstancesTask(
+            CreateTagInstancesTaskKindFixtures.any,
+          ),
+        };
+
+        createTagInstancesTaskGraphExpandCommandFixture = {
+          context: {
+            graph: {
+              nodes: new Set(),
+            },
+            requestId: Symbol(),
+            serviceIdAncestorList: ReadOnlyLinkedListImplementation.build(),
+            serviceIdToRequestCreateInstanceTaskKindNode: new Map(),
+            serviceIdToSingletonCreateInstanceTaskKindNode: new Map(),
+          },
+          node: nodeFixture,
+          taskKindType: TaskGraphExpandCommandType.createTagInstances,
+        };
+
+        const containerRequestServiceFixture: ContainerRequestService = {
+          _type: Symbol(),
+        } as unknown as ContainerRequestService;
+        const containerSingletonServiceFixture: ContainerSingletonService = {
+          _type: Symbol(),
+        } as unknown as ContainerSingletonService;
+
+        createInstanceTaskKindGraphNodeDependencyFixture = {
+          dependencies: undefined,
+          element: new CreateInstanceTask(
+            {
+              binding: ValueBindingFixtures.any,
+              requestId:
+                createTagInstancesTaskGraphExpandCommandFixture.context
+                  .requestId,
+              type: TaskKindType.createInstance,
+            },
+            containerRequestServiceFixture,
+            containerSingletonServiceFixture,
+          ),
+        };
+
+        bindingServiceMock.getByTag.mockReturnValueOnce([
+          ValueBindingFixtures.any,
+        ]);
+
+        createCreateInstanceTaskGraphNodeCommandHandlerMock.handle.mockReturnValueOnce(
+          createInstanceTaskKindGraphNodeDependencyFixture,
+        );
+
+        result = createTagInstancesTaskGraphExpandCommandHandler.handle(
+          createTagInstancesTaskGraphExpandCommandFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call bindingService.getByTag()', () => {
+        expect(bindingServiceMock.getByTag).toHaveBeenCalledTimes(1);
+        expect(bindingServiceMock.getByTag).toHaveBeenCalledWith(
+          nodeFixture.element.kind.tag,
+          true,
+        );
+      });
+
+      it('should call createCreateInstanceTaskGraphNodeCommandHandler.handle()', () => {
+        const expectedCreateCreateInstanceTaskGraphNodeCommand: CreateCreateInstanceTaskGraphNodeCommand =
+          {
+            context: {
+              ...createTagInstancesTaskGraphExpandCommandFixture.context,
+              taskKind: {
+                binding: ValueBindingFixtures.any,
+                requestId:
+                  createTagInstancesTaskGraphExpandCommandFixture.context
+                    .requestId,
+                type: TaskKindType.createInstance,
+              },
+            },
+          };
+
+        expect(
+          createCreateInstanceTaskGraphNodeCommandHandlerMock.handle,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          createCreateInstanceTaskGraphNodeCommandHandlerMock.handle,
+        ).toHaveBeenCalledWith(
+          expectedCreateCreateInstanceTaskGraphNodeCommand,
+        );
+      });
+
+      it('should call addNodesToGraph()', () => {
+        const expectedNodeDependency: cuaktask.NodeDependency<
+          cuaktask.Task<TaskKind>
+        > = {
+          nodes: [createInstanceTaskKindGraphNodeDependencyFixture],
+          type: cuaktask.NodeDependenciesType.and,
+        };
+
+        expect(addNodesToGraph).toHaveBeenCalledTimes(1);
+        expect(addNodesToGraph).toHaveBeenCalledWith(
+          createTagInstancesTaskGraphExpandCommandFixture.context.graph,
+          expectedNodeDependency,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});

--- a/packages/iocuak/src/createInstanceTask/modules/cuaktask/CreateTagInstancesTaskGraphExpandCommandHandler.ts
+++ b/packages/iocuak/src/createInstanceTask/modules/cuaktask/CreateTagInstancesTaskGraphExpandCommandHandler.ts
@@ -1,0 +1,129 @@
+import * as cuaktask from '@cuaklabs/cuaktask';
+
+import { Binding } from '../../../binding/models/domain/Binding';
+import { BindingTag } from '../../../binding/models/domain/BindingTag';
+import { BindingService } from '../../../binding/services/domain/BindingService';
+import { Handler } from '../../../common/modules/domain/Handler';
+import { mapIterable } from '../../../common/utils/mapIterable';
+import { CreateCreateInstanceTaskGraphNodeCommand } from '../../models/cuaktask/CreateCreateInstanceTaskGraphNodeCommand';
+import { CreateInstanceTaskGraphExpandOperationContext } from '../../models/cuaktask/CreateInstanceTaskGraphExpandOperationContext';
+import { CreateTagInstancesTaskGraphExpandCommand } from '../../models/cuaktask/CreateTagInstancesTaskGraphExpandCommand';
+import { CreateInstanceTaskKind } from '../../models/domain/CreateInstanceTaskKind';
+import { TaskKind } from '../../models/domain/TaskKind';
+import { TaskKindType } from '../../models/domain/TaskKindType';
+import { addNodesToGraph } from '../../utils/addNodesToGraph';
+
+export class CreateTagInstancesTaskGraphExpandCommandHandler
+  implements Handler<CreateTagInstancesTaskGraphExpandCommand, void>
+{
+  readonly #bindingService: BindingService;
+  readonly #createCreateInstanceTaskGraphNodeCommandHandler: Handler<
+    CreateCreateInstanceTaskGraphNodeCommand,
+    cuaktask.NodeDependency<cuaktask.Task<TaskKind>>
+  >;
+
+  constructor(
+    bindingService: BindingService,
+    createCreateInstanceTaskGraphNodeCommandHandler: Handler<
+      CreateCreateInstanceTaskGraphNodeCommand,
+      cuaktask.NodeDependency<cuaktask.Task<TaskKind>>
+    >,
+  ) {
+    this.#bindingService = bindingService;
+    this.#createCreateInstanceTaskGraphNodeCommandHandler =
+      createCreateInstanceTaskGraphNodeCommandHandler;
+  }
+
+  public handle(
+    createTagInstancesTaskGraphExpandCommand: CreateTagInstancesTaskGraphExpandCommand,
+  ): void {
+    const nodeDependencies: cuaktask.NodeDependencies<cuaktask.Task<TaskKind>> =
+      this.#createCreateInstanceTaskGraphNodeDependencyFromTag(
+        createTagInstancesTaskGraphExpandCommand.context,
+        createTagInstancesTaskGraphExpandCommand.node.element.kind.tag,
+      );
+
+    createTagInstancesTaskGraphExpandCommand.node.dependencies =
+      nodeDependencies;
+
+    addNodesToGraph(
+      createTagInstancesTaskGraphExpandCommand.context.graph,
+      nodeDependencies,
+    );
+  }
+
+  #createCreateInstanceTaskGraphNodeDependencyFromBinding(
+    context: CreateInstanceTaskGraphExpandOperationContext,
+    binding: Binding,
+  ): cuaktask.NodeDependency<cuaktask.Task<TaskKind>> {
+    const createInstanceTaskKind: CreateInstanceTaskKind = {
+      binding: binding,
+      requestId: context.requestId,
+      type: TaskKindType.createInstance,
+    };
+
+    const createInstanceTaskKindGraphNodeDependency: cuaktask.NodeDependency<
+      cuaktask.Task<TaskKind>
+    > = this.#createCreateInstanceTaskGraphNodeDependencyFromTaskKind(
+      context,
+      createInstanceTaskKind,
+    );
+
+    return createInstanceTaskKindGraphNodeDependency;
+  }
+
+  #createCreateInstanceTaskGraphNodeDependencyFromTaskKind(
+    context: CreateInstanceTaskGraphExpandOperationContext,
+    createInstanceTaskKind: CreateInstanceTaskKind,
+  ): cuaktask.NodeDependency<cuaktask.Task<TaskKind>> {
+    const createCreateInstanceTaskGraphNodeCommand: CreateCreateInstanceTaskGraphNodeCommand =
+      {
+        context: {
+          ...context,
+          taskKind: createInstanceTaskKind,
+        },
+      };
+
+    const createInstanceTaskKindGraphNodeDependency: cuaktask.NodeDependency<
+      cuaktask.Task<TaskKind>
+    > = this.#createCreateInstanceTaskGraphNodeCommandHandler.handle(
+      createCreateInstanceTaskGraphNodeCommand,
+    );
+
+    return createInstanceTaskKindGraphNodeDependency;
+  }
+
+  #createCreateInstanceTaskGraphNodeDependencyFromTag(
+    context: CreateInstanceTaskGraphExpandOperationContext,
+    tag: BindingTag,
+  ): cuaktask.NodeDependencies<cuaktask.Task<TaskKind>> {
+    const bindings: Iterable<Binding> = this.#getBindings(tag);
+
+    const tagServiceNodes: Iterable<
+      cuaktask.NodeDependency<cuaktask.Task<TaskKind>>
+    > = mapIterable(bindings, (binding: Binding) =>
+      this.#createCreateInstanceTaskGraphNodeDependencyFromBinding(
+        context,
+        binding,
+      ),
+    );
+
+    const nodeDependency: cuaktask.AndNodeDependencies<
+      cuaktask.Task<TaskKind>
+    > = {
+      nodes: [...tagServiceNodes],
+      type: cuaktask.NodeDependenciesType.and,
+    };
+
+    return nodeDependency;
+  }
+
+  #getBindings(tag: BindingTag): Iterable<Binding> {
+    const bindings: Iterable<Binding> = this.#bindingService.getByTag(
+      tag,
+      true,
+    );
+
+    return bindings;
+  }
+}

--- a/packages/iocuak/src/createInstanceTask/modules/cuaktask/GetInstanceDependenciesTaskGraphExpandCommandHandler.spec.ts
+++ b/packages/iocuak/src/createInstanceTask/modules/cuaktask/GetInstanceDependenciesTaskGraphExpandCommandHandler.spec.ts
@@ -2,6 +2,8 @@ import * as cuaktask from '@cuaklabs/cuaktask';
 import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import * as jestMock from 'jest-mock';
 
+jest.mock('../../utils/addNodesToGraph');
+
 import { TypeBindingFixtures } from '../../../binding/fixtures/domain/TypeBindingFixtures';
 import { ValueBindingFixtures } from '../../../binding/fixtures/domain/ValueBindingFixtures';
 import { BindingService } from '../../../binding/services/domain/BindingService';
@@ -20,6 +22,7 @@ import { TaskGraphExpandCommandType } from '../../models/cuaktask/TaskGraphExpan
 import { GetInstanceDependenciesTaskKind } from '../../models/domain/GetInstanceDependenciesTaskKind';
 import { TaskKind } from '../../models/domain/TaskKind';
 import { TaskKindType } from '../../models/domain/TaskKindType';
+import { addNodesToGraph } from '../../utils/addNodesToGraph';
 import { GetInstanceDependenciesTaskGraphExpandCommandHandler } from './GetInstanceDependenciesTaskGraphExpandCommandHandler';
 
 describe(GetInstanceDependenciesTaskGraphExpandCommandHandler.name, () => {
@@ -157,14 +160,19 @@ describe(GetInstanceDependenciesTaskGraphExpandCommandHandler.name, () => {
           );
         });
 
-        it('should expand graph nodes', () => {
-          expect(
+        it('should call addNodesToGraph()', () => {
+          const expectedNodeDependency: cuaktask.NodeDependency<
+            cuaktask.Task<TaskKind>
+          > = {
+            nodes: [createInstanceTaskKindGraphNodeDependencyFixture],
+            type: cuaktask.NodeDependenciesType.and,
+          };
+
+          expect(addNodesToGraph).toHaveBeenCalledTimes(1);
+          expect(addNodesToGraph).toHaveBeenCalledWith(
             getInstanceDependenciesTaskGraphExpandCommandFixture.context.graph,
-          ).toStrictEqual({
-            nodes: new Set<cuaktask.Node<cuaktask.Task<TaskKind>>>([
-              createInstanceTaskKindGraphNodeDependencyFixture,
-            ]),
-          });
+            expectedNodeDependency,
+          );
         });
 
         it('should set node dependencies', () => {
@@ -288,14 +296,24 @@ describe(GetInstanceDependenciesTaskGraphExpandCommandHandler.name, () => {
           );
         });
 
-        it('should expand graph nodes', () => {
-          expect(
+        it('should call addNodesToGraph()', () => {
+          const expectedNodeDependency: cuaktask.NodeDependency<
+            cuaktask.Task<TaskKind>
+          > = {
+            nodes: [
+              {
+                nodes: [createInstanceTaskKindGraphNodeDependencyFixture],
+                type: cuaktask.NodeDependenciesType.and,
+              },
+            ],
+            type: cuaktask.NodeDependenciesType.and,
+          };
+
+          expect(addNodesToGraph).toHaveBeenCalledTimes(1);
+          expect(addNodesToGraph).toHaveBeenCalledWith(
             getInstanceDependenciesTaskGraphExpandCommandFixture.context.graph,
-          ).toStrictEqual({
-            nodes: new Set<cuaktask.Node<cuaktask.Task<TaskKind>>>([
-              createInstanceTaskKindGraphNodeDependencyFixture,
-            ]),
-          });
+            expectedNodeDependency,
+          );
         });
 
         it('should set node dependencies', () => {

--- a/packages/iocuak/src/createInstanceTask/modules/cuaktask/GetInstanceDependenciesTaskGraphExpandCommandHandler.ts
+++ b/packages/iocuak/src/createInstanceTask/modules/cuaktask/GetInstanceDependenciesTaskGraphExpandCommandHandler.ts
@@ -17,6 +17,7 @@ import { CreateInstanceTaskKind } from '../../models/domain/CreateInstanceTaskKi
 import { GetInstanceDependenciesTaskKind } from '../../models/domain/GetInstanceDependenciesTaskKind';
 import { TaskKind } from '../../models/domain/TaskKind';
 import { TaskKindType } from '../../models/domain/TaskKindType';
+import { addNodesToGraph } from '../../utils/addNodesToGraph';
 
 export class GetInstanceDependenciesTaskGraphExpandCommandHandler
   implements Handler<GetInstanceDependenciesTaskGraphExpandCommand, void>
@@ -68,31 +69,10 @@ export class GetInstanceDependenciesTaskGraphExpandCommandHandler
       type: cuaktask.NodeDependenciesType.and,
     };
 
-    this.#addNodesToGraph(
+    addNodesToGraph(
       getInstanceDependenciesTaskGraphExpandCommand.context.graph,
       getInstanceDependenciesTaskGraphExpandCommand.node.dependencies,
     );
-  }
-
-  #addNodesToGraph(
-    graph: cuaktask.Graph<cuaktask.Task<unknown>>,
-    nodeDependencies: cuaktask.NodeDependencies<cuaktask.Task<unknown>>,
-  ): void {
-    for (const nodeDependency of nodeDependencies.nodes) {
-      if (
-        (nodeDependency as cuaktask.NodeDependencies<cuaktask.Task<unknown>>)
-          .nodes === undefined
-      ) {
-        graph.nodes.add(
-          nodeDependency as cuaktask.Node<cuaktask.Task<unknown>>,
-        );
-      } else {
-        this.#addNodesToGraph(
-          graph,
-          nodeDependency as cuaktask.NodeDependencies<cuaktask.Task<unknown>>,
-        );
-      }
-    }
   }
 
   #createCreateInstanceTaskGraphNodeDependency(

--- a/packages/iocuak/src/createInstanceTask/utils/addNodesToGraph.spec.ts
+++ b/packages/iocuak/src/createInstanceTask/utils/addNodesToGraph.spec.ts
@@ -1,0 +1,97 @@
+import * as cuaktask from '@cuaklabs/cuaktask';
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
+import { addNodesToGraph } from './addNodesToGraph';
+
+describe(addNodesToGraph.name, () => {
+  describe('having a nodeDendencies with node dependencies', () => {
+    let nodeFixture: cuaktask.Node<cuaktask.Task<unknown>>;
+    let nodeDendenciesFixture: cuaktask.NodeDependencies<
+      cuaktask.Task<unknown>
+    >;
+
+    beforeAll(() => {
+      nodeFixture = {
+        dependencies: undefined,
+        element: {
+          _type: Symbol(),
+        } as unknown as cuaktask.Task<unknown>,
+      };
+
+      nodeDendenciesFixture = {
+        nodes: [nodeFixture],
+        type: cuaktask.NodeDependenciesType.and,
+      };
+    });
+
+    describe('when called', () => {
+      let graphFixture: cuaktask.Graph<cuaktask.Task<unknown>>;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        graphFixture = {
+          nodes: new Set(),
+        };
+
+        result = addNodesToGraph(graphFixture, nodeDendenciesFixture);
+      });
+
+      it('should set graph.nodes', () => {
+        expect(graphFixture.nodes).toStrictEqual(new Set([nodeFixture]));
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a nodeDendencies with node dependencies dependencies', () => {
+    let nodeFixture: cuaktask.Node<cuaktask.Task<unknown>>;
+    let nodeDendenciesFixture: cuaktask.NodeDependencies<
+      cuaktask.Task<unknown>
+    >;
+
+    beforeAll(() => {
+      nodeFixture = {
+        dependencies: undefined,
+        element: {
+          _type: Symbol(),
+        } as unknown as cuaktask.Task<unknown>,
+      };
+
+      nodeDendenciesFixture = {
+        nodes: [
+          {
+            nodes: [nodeFixture],
+            type: cuaktask.NodeDependenciesType.bitwiseOr,
+          },
+        ],
+        type: cuaktask.NodeDependenciesType.and,
+      };
+    });
+
+    describe('when called', () => {
+      let graphFixture: cuaktask.Graph<cuaktask.Task<unknown>>;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        graphFixture = {
+          nodes: new Set(),
+        };
+
+        result = addNodesToGraph(graphFixture, nodeDendenciesFixture);
+      });
+
+      it('should set graph.nodes', () => {
+        expect(graphFixture.nodes).toStrictEqual(new Set([nodeFixture]));
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});

--- a/packages/iocuak/src/createInstanceTask/utils/addNodesToGraph.ts
+++ b/packages/iocuak/src/createInstanceTask/utils/addNodesToGraph.ts
@@ -1,0 +1,23 @@
+import * as cuaktask from '@cuaklabs/cuaktask';
+
+export function addNodesToGraph<T>(
+  graph: cuaktask.Graph<cuaktask.Task<T>>,
+  nodeDependencies: cuaktask.NodeDependencies<cuaktask.Task<T>>,
+): void {
+  for (const nodeDependency of nodeDependencies.nodes) {
+    if (isNode(nodeDependency)) {
+      graph.nodes.add(nodeDependency);
+    } else {
+      addNodesToGraph(graph, nodeDependency);
+    }
+  }
+}
+
+function isNode<T>(
+  nodeDependency: cuaktask.NodeDependency<cuaktask.Task<T>>,
+): nodeDependency is cuaktask.Node<cuaktask.Task<T>> {
+  return (
+    (nodeDependency as cuaktask.NodeDependencies<cuaktask.Task<T>>).nodes ===
+    undefined
+  );
+}


### PR DESCRIPTION
### Added
- Added `addNodesToGraph`.
- Added `CreateTagInstancesTaskGraphExpandCommandHandler`.

### Changed
- Updated precommit hook to launch tests related to uncommited changes.
- Updated `GetInstanceDependenciesTaskGraphExpandCommandHandler` to rely on addNodesToGraph.