### PR TITLE
Refactor/ioc 75 update get instance dependencies task graph expand command handler to rely on expanding a create tag instance task graph expand command

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,9 +19,7 @@ module.exports = {
   },
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    ecmaVersion: 2021,
-    sourceType: 'module',
-    project: './tsconfig.json',
+    project: ['./packages/*/tsconfig.json'],
     tsconfigRootDir: __dirname,
   },
   plugins: ['@typescript-eslint', 'import'],

--- a/packages/iocuak/src/container/modules/api/ContainerApi.spec.ts
+++ b/packages/iocuak/src/container/modules/api/ContainerApi.spec.ts
@@ -367,6 +367,7 @@ describe(ContainerApi.name, () => {
           GetInstanceDependenciesTaskGraphExpandCommandHandler,
         ).toHaveBeenCalledWith(
           containerBindingServiceImplementationFixture,
+          taskGraphExpandCommandHandlerMock,
           createCreateInstanceTaskGraphNodeCommandHandlerFixture,
           metadataServiceImplementationFixture,
         );

--- a/packages/iocuak/src/container/modules/api/ContainerApi.ts
+++ b/packages/iocuak/src/container/modules/api/ContainerApi.ts
@@ -242,6 +242,7 @@ export class ContainerApi extends ContainerServiceApiImplementation {
       void
     > = new GetInstanceDependenciesTaskGraphExpandCommandHandler(
       containerBindingService,
+      taskGraphExpandCommandHandler,
       createCreateInstanceTaskGraphNodeCommandHandler,
       metadataService,
     );

--- a/packages/iocuak/src/createInstanceTask/fixtures/domain/CreateTagInstancesTaskKindFixtures.ts
+++ b/packages/iocuak/src/createInstanceTask/fixtures/domain/CreateTagInstancesTaskKindFixtures.ts
@@ -4,7 +4,6 @@ import { TaskKindType } from '../../models/domain/TaskKindType';
 export class CreateTagInstancesTaskKindFixtures {
   public static get any(): CreateTagInstancesTaskKind {
     const fixture: CreateTagInstancesTaskKind = {
-      requestId: Symbol(),
       tag: Symbol(),
       type: TaskKindType.createTagInstances,
     };

--- a/packages/iocuak/src/createInstanceTask/models/cuaktask/TaskGraphExpandCommand.ts
+++ b/packages/iocuak/src/createInstanceTask/models/cuaktask/TaskGraphExpandCommand.ts
@@ -1,6 +1,8 @@
 import { CreateInstanceTaskGraphExpandCommand } from './CreateInstanceTaskGraphExpandCommand';
+import { CreateTagInstancesTaskGraphExpandCommand } from './CreateTagInstancesTaskGraphExpandCommand';
 import { GetInstanceDependenciesTaskGraphExpandCommand } from './GetInstanceDependenciesTaskGraphExpandCommand';
 
 export type TaskGraphExpandCommand =
   | CreateInstanceTaskGraphExpandCommand
+  | CreateTagInstancesTaskGraphExpandCommand
   | GetInstanceDependenciesTaskGraphExpandCommand;

--- a/packages/iocuak/src/createInstanceTask/models/domain/CreateTagInstancesTaskKind.ts
+++ b/packages/iocuak/src/createInstanceTask/models/domain/CreateTagInstancesTaskKind.ts
@@ -1,8 +1,8 @@
 import { BindingTag } from '../../../binding/models/domain/BindingTag';
-import { BaseRequestTaskKind } from './BaseRequestTaskKind';
+import { BaseTaskKind } from './BaseTaskKind';
 import { TaskKindType } from './TaskKindType';
 
 export interface CreateTagInstancesTaskKind
-  extends BaseRequestTaskKind<TaskKindType.createTagInstances> {
+  extends BaseTaskKind<TaskKindType.createTagInstances> {
   tag: BindingTag;
 }

--- a/packages/iocuak/src/createInstanceTask/utils/addNodesToGraph.spec.ts
+++ b/packages/iocuak/src/createInstanceTask/utils/addNodesToGraph.spec.ts
@@ -4,11 +4,12 @@ import { beforeAll, describe, expect, it } from '@jest/globals';
 import { addNodesToGraph } from './addNodesToGraph';
 
 describe(addNodesToGraph.name, () => {
-  describe('having a nodeDendencies with node dependencies', () => {
+  describe('having a node with node dependencies', () => {
     let nodeFixture: cuaktask.Node<cuaktask.Task<unknown>>;
     let nodeDendenciesFixture: cuaktask.NodeDependencies<
       cuaktask.Task<unknown>
     >;
+    let nodeDendencyFixture: cuaktask.Node<cuaktask.Task<unknown>>;
 
     beforeAll(() => {
       nodeFixture = {
@@ -22,6 +23,13 @@ describe(addNodesToGraph.name, () => {
         nodes: [nodeFixture],
         type: cuaktask.NodeDependenciesType.and,
       };
+
+      nodeDendencyFixture = {
+        dependencies: nodeDendenciesFixture,
+        element: {
+          _type: Symbol(),
+        } as unknown as cuaktask.Task<unknown>,
+      };
     });
 
     describe('when called', () => {
@@ -34,11 +42,13 @@ describe(addNodesToGraph.name, () => {
           nodes: new Set(),
         };
 
-        result = addNodesToGraph(graphFixture, nodeDendenciesFixture);
+        result = addNodesToGraph(graphFixture, nodeDendencyFixture);
       });
 
       it('should set graph.nodes', () => {
-        expect(graphFixture.nodes).toStrictEqual(new Set([nodeFixture]));
+        expect(graphFixture.nodes).toStrictEqual(
+          new Set([nodeDendencyFixture, nodeFixture]),
+        );
       });
 
       it('should return undefined', () => {
@@ -47,11 +57,9 @@ describe(addNodesToGraph.name, () => {
     });
   });
 
-  describe('having a nodeDendencies with node dependencies dependencies', () => {
+  describe('having a nodeDependency with node dependencies dependencies', () => {
     let nodeFixture: cuaktask.Node<cuaktask.Task<unknown>>;
-    let nodeDendenciesFixture: cuaktask.NodeDependencies<
-      cuaktask.Task<unknown>
-    >;
+    let nodeDendencyFixture: cuaktask.NodeDependencies<cuaktask.Task<unknown>>;
 
     beforeAll(() => {
       nodeFixture = {
@@ -61,7 +69,7 @@ describe(addNodesToGraph.name, () => {
         } as unknown as cuaktask.Task<unknown>,
       };
 
-      nodeDendenciesFixture = {
+      nodeDendencyFixture = {
         nodes: [
           {
             nodes: [nodeFixture],
@@ -82,7 +90,7 @@ describe(addNodesToGraph.name, () => {
           nodes: new Set(),
         };
 
-        result = addNodesToGraph(graphFixture, nodeDendenciesFixture);
+        result = addNodesToGraph(graphFixture, nodeDendencyFixture);
       });
 
       it('should set graph.nodes', () => {

--- a/packages/iocuak/src/createInstanceTask/utils/addNodesToGraph.ts
+++ b/packages/iocuak/src/createInstanceTask/utils/addNodesToGraph.ts
@@ -2,13 +2,17 @@ import * as cuaktask from '@cuaklabs/cuaktask';
 
 export function addNodesToGraph<T>(
   graph: cuaktask.Graph<cuaktask.Task<T>>,
-  nodeDependencies: cuaktask.NodeDependencies<cuaktask.Task<T>>,
+  nodeDependency: cuaktask.NodeDependency<cuaktask.Task<T>>,
 ): void {
-  for (const nodeDependency of nodeDependencies.nodes) {
-    if (isNode(nodeDependency)) {
-      graph.nodes.add(nodeDependency);
-    } else {
-      addNodesToGraph(graph, nodeDependency);
+  if (isNode(nodeDependency)) {
+    graph.nodes.add(nodeDependency);
+
+    if (nodeDependency.dependencies !== undefined) {
+      addNodesToGraph(graph, nodeDependency.dependencies);
+    }
+  } else {
+    for (const nodeDependencyNode of nodeDependency.nodes) {
+      addNodesToGraph(graph, nodeDependencyNode);
     }
   }
 }


### PR DESCRIPTION
### Changed
- Updated `CreateTagInstancesTaskKind` to extend `BaseTaskKind`.
- Updated eslint config to use packages tsconfig.
- Updated `addNodesToGraph` to require a node dependency.
- Updated `TaskGraphExpandCommand` to include `CreateTagInstancesTaskGraphExpandCommand`.
- Updated `GetInstanceDependenciesTaskGraphExpandCommandHandler` to rely on bus to handle tag dependencies.