### PR TITLE
Add e2e test to ensure tag related features work

### DIFF
--- a/packages/iocuak/src/binding/models/api/BaseBindingApi.ts
+++ b/packages/iocuak/src/binding/models/api/BaseBindingApi.ts
@@ -1,7 +1,9 @@
 import { ServiceId } from '../../../common/models/domain/ServiceId';
+import { BindingTag } from '../domain/BindingTag';
 import { BindingTypeApi } from './BindingTypeApi';
 
 export interface BaseBindingApi {
   id: ServiceId;
   bindingType: BindingTypeApi;
+  tags: BindingTag[];
 }

--- a/packages/iocuak/src/binding/utils/api/convertBindingToBindingApi.spec.ts
+++ b/packages/iocuak/src/binding/utils/api/convertBindingToBindingApi.spec.ts
@@ -1,3 +1,5 @@
+import { beforeAll, describe, expect, it } from '@jest/globals';
+
 import { TypeBindingFixtures } from '../../fixtures/domain/TypeBindingFixtures';
 import { ValueBindingFixtures } from '../../fixtures/domain/ValueBindingFixtures';
 import { BindingApi } from '../../models/api/BindingApi';
@@ -31,6 +33,7 @@ describe(convertBindingToBindingApi.name, () => {
           bindingType: BindingTypeApi.type,
           id: bindingFixture.id,
           scope: expectedScope,
+          tags: [...bindingFixture.tags],
           type: bindingFixture.type,
         };
 
@@ -57,6 +60,7 @@ describe(convertBindingToBindingApi.name, () => {
         const expected: BindingApi = {
           bindingType: BindingTypeApi.value,
           id: bindingFixture.id,
+          tags: [...bindingFixture.tags],
           value: bindingFixture.value,
         };
 

--- a/packages/iocuak/src/binding/utils/api/convertBindingToBindingApi.ts
+++ b/packages/iocuak/src/binding/utils/api/convertBindingToBindingApi.ts
@@ -28,6 +28,7 @@ export function convertBindingToBindingApi<TInstance, TArgs extends unknown[]>(
         bindingType: BindingTypeApi.type,
         id: binding.id,
         scope: bindingScopeToBindingScopeApiMap[binding.scope],
+        tags: [...binding.tags],
         type: binding.type,
       };
       break;
@@ -35,6 +36,7 @@ export function convertBindingToBindingApi<TInstance, TArgs extends unknown[]>(
       bindingApi = {
         bindingType: BindingTypeApi.value,
         id: binding.id,
+        tags: [...binding.tags],
         value: binding.value,
       };
       break;

--- a/packages/iocuak/src/container/modules/api/ContainerApi.spec.ts
+++ b/packages/iocuak/src/container/modules/api/ContainerApi.spec.ts
@@ -32,6 +32,9 @@ jest.mock(
   '../../../createInstanceTask/modules/cuaktask/CreateInstanceTaskNodeExpandCommandHandler',
 );
 jest.mock(
+  '../../../createInstanceTask/modules/cuaktask/CreateTagInstancesTaskNodeExpandCommandHandler',
+);
+jest.mock(
   '../../../createInstanceTask/modules/cuaktask/GetInstanceDependenciesTaskNodeExpandCommandHandler',
 );
 jest.mock(
@@ -55,6 +58,7 @@ import { CreateCreateTransientScopedInstanceTaskNodeCommandHandler } from '../..
 import { CreateCreateTypeBindingInstanceTaskNodeCommandHandler } from '../../../createInstanceTask/modules/cuaktask/CreateCreateTypeBindingInstanceTaskNodeCommandHandler';
 import { CreateInstanceTaskGraphEngine } from '../../../createInstanceTask/modules/cuaktask/CreateInstanceTaskGraphEngine';
 import { CreateInstanceTaskNodeExpandCommandHandler } from '../../../createInstanceTask/modules/cuaktask/CreateInstanceTaskNodeExpandCommandHandler';
+import { CreateTagInstancesTaskNodeExpandCommandHandler } from '../../../createInstanceTask/modules/cuaktask/CreateTagInstancesTaskNodeExpandCommandHandler';
 import { GetInstanceDependenciesTaskNodeExpandCommandHandler } from '../../../createInstanceTask/modules/cuaktask/GetInstanceDependenciesTaskNodeExpandCommandHandler';
 import { TaskNodeExpandCommandHandler } from '../../../createInstanceTask/modules/cuaktask/TaskNodeExpandCommandHandler';
 import { MetadataServiceImplementation } from '../../../metadata/services/domain/MetadataServiceImplementation';
@@ -88,12 +92,13 @@ describe(ContainerApi.name, () => {
       let containerSingletonServiceImplementationFixture: ContainerSingletonServiceImplementation;
 
       let taskGraphExpandCommandHandlerMock: jest.Mocked<TaskNodeExpandCommandHandler>;
-      let createInstanceTaskGraphExpandCommandHandlerFixture: CreateInstanceTaskNodeExpandCommandHandler;
       let createCreateRequestScopedInstanceTaskGraphNodeCommandHandlerFixture: CreateCreateRequestScopedInstanceTaskNodeCommandHandler;
       let createCreateSingletonScopedInstanceTaskGraphNodeCommandHandlerFixture: CreateCreateSingletonScopedInstanceTaskNodeCommandHandler;
       let createCreateTransientScopedInstanceTaskGraphNodeCommandHandlerFixture: CreateCreateTransientScopedInstanceTaskNodeCommandHandler;
       let createCreateTypeBindingInstanceTaskGraphNodeCommandHandlerFixture: CreateCreateTypeBindingInstanceTaskNodeCommandHandler;
       let createCreateInstanceTaskGraphNodeCommandHandlerFixture: CreateCreateInstanceTaskNodeCommandHandler;
+      let createInstanceTaskGraphExpandCommandHandlerFixture: CreateInstanceTaskNodeExpandCommandHandler;
+      let createTagInstancesTaskNodeExpandCommandHandlerFixture: CreateTagInstancesTaskNodeExpandCommandHandler;
       let getInstanceDependenciesTaskGraphExpandCommandHandlerFixture: GetInstanceDependenciesTaskNodeExpandCommandHandler;
       let createInstanceTaskGraphEngineFixture: CreateInstanceTaskGraphEngine;
       let rootedTaskGraphRunnerFixture: cuaktask.RootedTaskGraphRunner;
@@ -170,13 +175,6 @@ describe(ContainerApi.name, () => {
           taskGraphExpandCommandHandlerMock,
         );
 
-        createInstanceTaskGraphExpandCommandHandlerFixture =
-          buildEmptyFixture();
-        bindFixtureToConstructor(
-          CreateInstanceTaskNodeExpandCommandHandler,
-          createInstanceTaskGraphExpandCommandHandlerFixture,
-        );
-
         createCreateRequestScopedInstanceTaskGraphNodeCommandHandlerFixture =
           buildEmptyFixture();
         bindFixtureToConstructor(
@@ -210,6 +208,20 @@ describe(ContainerApi.name, () => {
         bindFixtureToConstructor(
           CreateCreateInstanceTaskNodeCommandHandler,
           createCreateInstanceTaskGraphNodeCommandHandlerFixture,
+        );
+
+        createInstanceTaskGraphExpandCommandHandlerFixture =
+          buildEmptyFixture();
+        bindFixtureToConstructor(
+          CreateInstanceTaskNodeExpandCommandHandler,
+          createInstanceTaskGraphExpandCommandHandlerFixture,
+        );
+
+        createTagInstancesTaskNodeExpandCommandHandlerFixture =
+          buildEmptyFixture();
+        bindFixtureToConstructor(
+          CreateTagInstancesTaskNodeExpandCommandHandler,
+          createTagInstancesTaskNodeExpandCommandHandlerFixture,
         );
 
         getInstanceDependenciesTaskGraphExpandCommandHandlerFixture =
@@ -282,16 +294,6 @@ describe(ContainerApi.name, () => {
         expect(TaskNodeExpandCommandHandler).toHaveBeenCalledWith();
       });
 
-      it('should call new CreateInstanceTaskGraphExpandCommandHandler()', () => {
-        expect(
-          CreateInstanceTaskNodeExpandCommandHandler,
-        ).toHaveBeenCalledTimes(1);
-        expect(CreateInstanceTaskNodeExpandCommandHandler).toHaveBeenCalledWith(
-          taskGraphExpandCommandHandlerMock,
-          metadataServiceImplementationFixture,
-        );
-      });
-
       it('should call new CreateCreateRequestScopedInstanceTaskGraphNodeCommandHandler()', () => {
         expect(
           CreateCreateRequestScopedInstanceTaskNodeCommandHandler,
@@ -352,6 +354,28 @@ describe(ContainerApi.name, () => {
           containerRequestServiceImplementationFixture,
           containerSingletonServiceImplementationFixture,
           createCreateTypeBindingInstanceTaskGraphNodeCommandHandlerFixture,
+        );
+      });
+
+      it('should call new CreateInstanceTaskGraphExpandCommandHandler()', () => {
+        expect(
+          CreateInstanceTaskNodeExpandCommandHandler,
+        ).toHaveBeenCalledTimes(1);
+        expect(CreateInstanceTaskNodeExpandCommandHandler).toHaveBeenCalledWith(
+          taskGraphExpandCommandHandlerMock,
+          metadataServiceImplementationFixture,
+        );
+      });
+
+      it('should call new CreateTagInstancesTaskNodeExpandCommandHandler()', () => {
+        expect(
+          CreateTagInstancesTaskNodeExpandCommandHandler,
+        ).toHaveBeenCalledTimes(1);
+        expect(
+          CreateTagInstancesTaskNodeExpandCommandHandler,
+        ).toHaveBeenCalledWith(
+          containerBindingServiceImplementationFixture,
+          createCreateInstanceTaskGraphNodeCommandHandlerFixture,
         );
       });
 

--- a/packages/iocuak/src/container/modules/api/ContainerApi.ts
+++ b/packages/iocuak/src/container/modules/api/ContainerApi.ts
@@ -11,6 +11,7 @@ import { ContainerModuleTaskDependencyEngine } from '../../../containerModuleTas
 import { CreateCreateInstanceTaskNodeCommand } from '../../../createInstanceTask/models/cuaktask/CreateCreateInstanceTaskNodeCommand';
 import { CreateCreateTypeBindingInstanceTaskNodeCommand } from '../../../createInstanceTask/models/cuaktask/CreateCreateTypeBindingInstanceTaskNodeCommand';
 import { CreateInstanceTaskNodeExpandCommand } from '../../../createInstanceTask/models/cuaktask/CreateInstanceTaskNodeExpandCommand';
+import { CreateTagInstancesTaskNodeExpandCommand } from '../../../createInstanceTask/models/cuaktask/CreateTagInstancesTaskNodeExpandCommand';
 import { GetInstanceDependenciesTaskNodeExpandCommand } from '../../../createInstanceTask/models/cuaktask/GetInstanceDependenciesTaskNodeExpandCommand';
 import { TaskNodeExpandCommand } from '../../../createInstanceTask/models/cuaktask/TaskNodeExpandCommand';
 import { TaskNodeExpandCommandType } from '../../../createInstanceTask/models/cuaktask/TaskNodeExpandCommandType';
@@ -22,6 +23,7 @@ import { CreateCreateTransientScopedInstanceTaskNodeCommandHandler } from '../..
 import { CreateCreateTypeBindingInstanceTaskNodeCommandHandler } from '../../../createInstanceTask/modules/cuaktask/CreateCreateTypeBindingInstanceTaskNodeCommandHandler';
 import { CreateInstanceTaskGraphEngine } from '../../../createInstanceTask/modules/cuaktask/CreateInstanceTaskGraphEngine';
 import { CreateInstanceTaskNodeExpandCommandHandler } from '../../../createInstanceTask/modules/cuaktask/CreateInstanceTaskNodeExpandCommandHandler';
+import { CreateTagInstancesTaskNodeExpandCommandHandler } from '../../../createInstanceTask/modules/cuaktask/CreateTagInstancesTaskNodeExpandCommandHandler';
 import { GetInstanceDependenciesTaskNodeExpandCommandHandler } from '../../../createInstanceTask/modules/cuaktask/GetInstanceDependenciesTaskNodeExpandCommandHandler';
 import { TaskNodeExpandCommandHandler } from '../../../createInstanceTask/modules/cuaktask/TaskNodeExpandCommandHandler';
 import { MetadataService } from '../../../metadata/services/domain/MetadataService';
@@ -223,20 +225,13 @@ export class ContainerApi extends ContainerServiceApiImplementation {
       TaskNodeExpandCommand,
       void | Promise<void>
     >,
-    containerBindingService: BindingService,
-    containerRequestService: ContainerRequestService,
-    containerSingletonService: ContainerSingletonService,
-    metadataService: MetadataService,
-  ): Handler<GetInstanceDependenciesTaskNodeExpandCommand, void> {
-    const createCreateInstanceTaskGraphNodeCommandHandler: Handler<
+    createCreateInstanceTaskGraphNodeCommandHandler: Handler<
       CreateCreateInstanceTaskNodeCommand,
       cuaktask.NodeDependency<cuaktask.Task<TaskKind>>
-    > = this.#initializeCreateCreateInstanceTaskGraphNodeCommandHandler(
-      taskGraphExpandCommandHandler,
-      containerRequestService,
-      containerSingletonService,
-    );
-
+    >,
+    containerBindingService: BindingService,
+    metadataService: MetadataService,
+  ): Handler<GetInstanceDependenciesTaskNodeExpandCommand, void> {
     const getInstanceDependenciesTaskGraphExpandCommandHandler: Handler<
       GetInstanceDependenciesTaskNodeExpandCommand,
       void
@@ -259,6 +254,15 @@ export class ContainerApi extends ContainerServiceApiImplementation {
     const taskGraphExpandCommandHandler: TaskNodeExpandCommandHandler =
       new TaskNodeExpandCommandHandler();
 
+    const createCreateInstanceTaskGraphNodeCommandHandler: Handler<
+      CreateCreateInstanceTaskNodeCommand,
+      cuaktask.NodeDependency<cuaktask.Task<TaskKind>>
+    > = this.#initializeCreateCreateInstanceTaskGraphNodeCommandHandler(
+      taskGraphExpandCommandHandler,
+      containerRequestService,
+      containerSingletonService,
+    );
+
     const createInstanceTaskGraphExpandCommandHandler: Handler<
       CreateInstanceTaskNodeExpandCommand,
       void
@@ -267,20 +271,32 @@ export class ContainerApi extends ContainerServiceApiImplementation {
       metadataService,
     );
 
+    const createTagInstancesTaskNodeExpandCommandHandler: Handler<
+      CreateTagInstancesTaskNodeExpandCommand,
+      void
+    > = new CreateTagInstancesTaskNodeExpandCommandHandler(
+      containerBindingService,
+      createCreateInstanceTaskGraphNodeCommandHandler,
+    );
+
     const getInstanceDependenciesTaskGraphExpandCommandHandler: Handler<
       GetInstanceDependenciesTaskNodeExpandCommand,
       void
     > = this.#initializeGetInstanceDependenciesTaskGraphExpandCommandHandler(
       taskGraphExpandCommandHandler,
+      createCreateInstanceTaskGraphNodeCommandHandler,
       containerBindingService,
-      containerRequestService,
-      containerSingletonService,
       metadataService,
     );
 
     taskGraphExpandCommandHandler.register(
       TaskNodeExpandCommandType.createInstance,
       createInstanceTaskGraphExpandCommandHandler,
+    );
+
+    taskGraphExpandCommandHandler.register(
+      TaskNodeExpandCommandType.createTagInstances,
+      createTagInstancesTaskNodeExpandCommandHandler,
     );
 
     taskGraphExpandCommandHandler.register(

--- a/packages/iocuak/src/container/services/api/ContainerServiceApiImplementation.spec.ts
+++ b/packages/iocuak/src/container/services/api/ContainerServiceApiImplementation.spec.ts
@@ -225,6 +225,7 @@ describe(ContainerServiceApiImplementation.name, () => {
         bindingApiFixture = {
           bindingType: BindingTypeApi.value,
           id: bindingFixture.id,
+          tags: [...bindingFixture.tags],
           value: bindingFixture.value,
         };
 

--- a/packages/iocuak/src/e2e/definitions/common/models/worlds/TagWorld.ts
+++ b/packages/iocuak/src/e2e/definitions/common/models/worlds/TagWorld.ts
@@ -1,0 +1,7 @@
+import { IWorld } from '@cucumber/cucumber';
+
+import { BindingTag } from '../../../../../binding/models/domain/BindingTag';
+
+export interface TagWorld extends IWorld {
+  tag: BindingTag;
+}

--- a/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithBindingWithRequestScope.ts
+++ b/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithBindingWithRequestScope.ts
@@ -20,6 +20,7 @@ export function getTypeServiceWithBindingWithRequestScope(): TypeServiceParamete
     bindingType: BindingTypeApi.type,
     id: Symbol(TypeServiceWithBindingWithRequestScope.name),
     scope: BindingScopeApi.request,
+    tags: [],
     type: TypeServiceWithBindingWithRequestScope,
   };
 

--- a/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithBindingWithRequestScopeAndDependenciesWithTransientScope.ts
+++ b/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithBindingWithRequestScopeAndDependenciesWithTransientScope.ts
@@ -30,6 +30,7 @@ export function getTypeServiceWithBindingWithRequestScopeAndDependenciesWithTran
       TypeServiceWithBindingWithRequestScopeAndDependenciesWithTransientScope.name,
     ),
     scope: BindingScopeApi.request,
+    tags: [],
     type: TypeServiceWithBindingWithRequestScopeAndDependenciesWithTransientScope,
   };
 

--- a/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithBindingWithSingletonScope.ts
+++ b/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithBindingWithSingletonScope.ts
@@ -20,6 +20,7 @@ export function getTypeServiceWithBindingWithSingletonScope(): TypeServiceParame
     bindingType: BindingTypeApi.type,
     id: Symbol(TypeServiceWithBindingWithSingletonScope.name),
     scope: BindingScopeApi.singleton,
+    tags: [],
     type: TypeServiceWithBindingWithSingletonScope,
   };
 

--- a/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithBindingWithSingletonScopeAndDependenciesWithTransientScope.ts
+++ b/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithBindingWithSingletonScopeAndDependenciesWithTransientScope.ts
@@ -30,6 +30,7 @@ export function getTypeServiceWithBindingWithSingletonScopeAndDependenciesWithTr
       TypeServiceWithBindingWithSingletonScopeAndDependenciesWithTransientScope.name,
     ),
     scope: BindingScopeApi.singleton,
+    tags: [],
     type: TypeServiceWithBindingWithSingletonScopeAndDependenciesWithTransientScope,
   };
 

--- a/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithBindingWithTransientScope.ts
+++ b/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithBindingWithTransientScope.ts
@@ -20,6 +20,7 @@ export function getTypeServiceWithBindingWithTransientScope(): TypeServiceParame
     bindingType: BindingTypeApi.type,
     id: Symbol(TypeServiceWithBindingWithTransientScope.name),
     scope: BindingScopeApi.transient,
+    tags: [],
     type: TypeServiceWithBindingWithTransientScope,
   };
 

--- a/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithBindingWithTransientScopeAndDependenciesWithTransientScope.ts
+++ b/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithBindingWithTransientScopeAndDependenciesWithTransientScope.ts
@@ -30,6 +30,7 @@ export function getTypeServiceWithBindingWithTransientScopeAndDependenciesWithTr
       TypeServiceWithBindingWithTransientScopeAndDependenciesWithTransientScope.name,
     ),
     scope: BindingScopeApi.transient,
+    tags: [],
     type: TypeServiceWithBindingWithTransientScopeAndDependenciesWithTransientScope,
   };
 

--- a/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithConstructorParameters.ts
+++ b/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithConstructorParameters.ts
@@ -49,6 +49,7 @@ export function getTypeServiceWithConstructorParameters(): TypeServiceParameter 
     bindingType: BindingTypeApi.type,
     id: Symbol(TypeServiceWithConstructorParameters.name),
     scope: BindingScopeApi.singleton,
+    tags: [],
     type: TypeServiceWithConstructorParameters,
   };
 

--- a/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithNoDependenciesParameter.ts
+++ b/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithNoDependenciesParameter.ts
@@ -20,6 +20,7 @@ export function getTypeServiceWithNoDependenciesParameter(): TypeServiceParamete
     bindingType: BindingTypeApi.type,
     id: Symbol(TypeServiceWithNoDependenciesParameter.name),
     scope: BindingScopeApi.request,
+    tags: [],
     type: TypeServiceWithNoDependenciesParameter,
   };
 

--- a/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithProperties.ts
+++ b/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithProperties.ts
@@ -44,6 +44,7 @@ export function getTypeServiceWithProperties(): TypeServiceParameter {
     bindingType: BindingTypeApi.type,
     id: Symbol(TypeServiceWithProperties.name),
     scope: BindingScopeApi.singleton,
+    tags: [],
     type: TypeServiceWithProperties,
   };
 

--- a/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithTwoDependenciesOfTheSameTypeWithRequestScope.ts
+++ b/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithTwoDependenciesOfTheSameTypeWithRequestScope.ts
@@ -32,6 +32,7 @@ export function getTypeServiceWithTwoDependenciesOfTheSameTypeWithRequestScope()
       TypeServiceWithTwoDependenciesOfTheSameTypeWithRequestScope.name,
     ),
     scope: BindingScopeApi.singleton,
+    tags: [],
     type: TypeServiceWithTwoDependenciesOfTheSameTypeWithRequestScope,
   };
 

--- a/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithTwoDependenciesOfTheSameTypeWithRequestScopeAndDependenciesWithTransientScope.ts
+++ b/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithTwoDependenciesOfTheSameTypeWithRequestScopeAndDependenciesWithTransientScope.ts
@@ -32,6 +32,7 @@ export function getTypeServiceWithTwoDependenciesOfTheSameTypeWithRequestScopeAn
       TypeServiceWithTwoDependenciesOfTheSameTypeWithRequestScopeAndDependenciesWithTransientScope.name,
     ),
     scope: BindingScopeApi.singleton,
+    tags: [],
     type: TypeServiceWithTwoDependenciesOfTheSameTypeWithRequestScopeAndDependenciesWithTransientScope,
   };
 

--- a/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithTwoDependenciesOfTheSameTypeWithSingletonScope.ts
+++ b/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithTwoDependenciesOfTheSameTypeWithSingletonScope.ts
@@ -32,6 +32,7 @@ export function getTypeServiceWithTwoDependenciesOfTheSameTypeWithSingletonScope
       TypeServiceWithTwoDependenciesOfTheSameTypeWithSingletonScope.name,
     ),
     scope: BindingScopeApi.singleton,
+    tags: [],
     type: TypeServiceWithTwoDependenciesOfTheSameTypeWithSingletonScope,
   };
 

--- a/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithTwoDependenciesOfTheSameTypeWithSingletonScopeAndDependenciesWithTransientScope.ts
+++ b/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithTwoDependenciesOfTheSameTypeWithSingletonScopeAndDependenciesWithTransientScope.ts
@@ -32,6 +32,7 @@ export function getTypeServiceWithTwoDependenciesOfTheSameTypeWithSingletonScope
       TypeServiceWithTwoDependenciesOfTheSameTypeWithSingletonScopeAndDependenciesWithTransientScope.name,
     ),
     scope: BindingScopeApi.singleton,
+    tags: [],
     type: TypeServiceWithTwoDependenciesOfTheSameTypeWithSingletonScopeAndDependenciesWithTransientScope,
   };
 

--- a/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithTwoDependenciesOfTheSameTypeWithTransientScope.ts
+++ b/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithTwoDependenciesOfTheSameTypeWithTransientScope.ts
@@ -32,6 +32,7 @@ export function getTypeServiceWithTwoDependenciesOfTheSameTypeWithTransientScope
       TypeServiceWithTwoDependenciesOfTheSameTypeWithTransientScope.name,
     ),
     scope: BindingScopeApi.singleton,
+    tags: [],
     type: TypeServiceWithTwoDependenciesOfTheSameTypeWithTransientScope,
   };
 

--- a/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithTwoDependenciesOfTheSameTypeWithTransientScopeAndDependenciesWithTransientScope.ts
+++ b/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithTwoDependenciesOfTheSameTypeWithTransientScopeAndDependenciesWithTransientScope.ts
@@ -32,6 +32,7 @@ export function getTypeServiceWithTwoDependenciesOfTheSameTypeWithTransientScope
       TypeServiceWithTwoDependenciesOfTheSameTypeWithTransientScopeAndDependenciesWithTransientScope.name,
     ),
     scope: BindingScopeApi.singleton,
+    tags: [],
     type: TypeServiceWithTwoDependenciesOfTheSameTypeWithTransientScopeAndDependenciesWithTransientScope,
   };
 

--- a/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithTypeServiceId.ts
+++ b/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithTypeServiceId.ts
@@ -20,6 +20,7 @@ export function getTypeServiceWithTypeServiceId(): TypeServiceParameter {
     bindingType: BindingTypeApi.type,
     id: TypeServiceWithTypeServiceId,
     scope: BindingScopeApi.singleton,
+    tags: [],
     type: TypeServiceWithTypeServiceId,
   };
 

--- a/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithUnboundClassTypeServiceConstructorParameters.ts
+++ b/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithUnboundClassTypeServiceConstructorParameters.ts
@@ -30,6 +30,7 @@ export function getTypeServiceWithUnboundClassTypeServiceConstructorParameters()
       TypeServiceWithUnboundClassTypeServiceConstructorParameters.name,
     ),
     scope: BindingScopeApi.singleton,
+    tags: [],
     type: TypeServiceWithUnboundClassTypeServiceConstructorParameters,
   };
 

--- a/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithUnboundClassTypeServiceProperties.ts
+++ b/packages/iocuak/src/e2e/definitions/common/parameters/typeService/getTypeServiceWithUnboundClassTypeServiceProperties.ts
@@ -28,6 +28,7 @@ export function getTypeServiceWithUnboundClassTypeServiceProperties(): TypeServi
     bindingType: BindingTypeApi.type,
     id: Symbol(TypeServiceWithUnboundClassTypeServiceProperties.name),
     scope: BindingScopeApi.singleton,
+    tags: [],
     type: TypeServiceWithUnboundClassTypeServiceProperties,
   };
 

--- a/packages/iocuak/src/e2e/definitions/common/parameters/valueService/getValueServiceParameter.ts
+++ b/packages/iocuak/src/e2e/definitions/common/parameters/valueService/getValueServiceParameter.ts
@@ -8,6 +8,7 @@ export function getValueServiceParameter(): ValueServiceParameter {
   const binding: ValueBindingApi = {
     bindingType: BindingTypeApi.value,
     id: Symbol('value-service'),
+    tags: [],
     value,
   };
 

--- a/packages/iocuak/src/e2e/definitions/common/stepDefinitions/commonDefinitions.ts
+++ b/packages/iocuak/src/e2e/definitions/common/stepDefinitions/commonDefinitions.ts
@@ -2,11 +2,16 @@ import { Given, Then } from '@cucumber/cucumber';
 import chai from 'chai';
 
 import { ResultWorld } from '../models/worlds/ResultWorld';
+import { TagWorld } from '../models/worlds/TagWorld';
 import { TwoResultsWorld } from '../models/worlds/TwoResultsWorld';
 import { TypeServiceWorld } from '../models/worlds/TypeServiceWorld';
 import { ValueServiceWorld } from '../models/worlds/ValueServiceWorld';
 import { TypeServiceParameter } from '../parameters/typeService/TypeServiceParameter';
 import { ValueServiceParameter } from '../parameters/valueService/ValueServiceParameter';
+
+Given<TagWorld>('a tag', function (): void {
+  this.tag = Symbol();
+});
 
 Given<TypeServiceWorld>(
   'a {typeService}',

--- a/packages/iocuak/src/e2e/features/container/createInstancesByTag.feature
+++ b/packages/iocuak/src/e2e/features/container/createInstancesByTag.feature
@@ -1,0 +1,26 @@
+Feature: Create instances by tag
+
+  Containers are able to create services by tag whenever the service is bound to the tag and all its dependencies are bound
+
+  Background: Having a container
+  Given a container
+  Given a tag
+
+  Rule: Any bound type service is instantiated
+
+    Scenario Outline: Bound value service request
+      Given a <type_service>
+      When the type binding is updated to include the tag
+      And the type service dependencies are bound
+      And the type service is bound
+      And instaces by tag are requested
+      Then an array with an instance from the type service is returned
+
+      Examples:
+        | type_service                                        |
+        | "type service with no dependencies"                 |
+        | "type service with binding with request scope"      |
+        | "type service with binding with singleton scope"    |
+        | "type service with binding with transient scope"    |
+        | "type service with constructor parameters"          |
+        | "type service with properties"                      |

--- a/packages/iocuak/src/metadata/services/api/MetadataServiceApiImplementation.spec.ts
+++ b/packages/iocuak/src/metadata/services/api/MetadataServiceApiImplementation.spec.ts
@@ -76,6 +76,7 @@ describe(MetadataServiceApiImplementation.name, () => {
           bindingType: BindingTypeApi.type,
           id: bindingFixture.id,
           scope: BindingScopeApi.singleton,
+          tags: [...bindingFixture.tags],
           type: bindingFixture.type,
         };
 


### PR DESCRIPTION
### Changed
- Updated `BaseBindingApi` with `tags`.
- Updated `ContainerApi` to register create tag instances handler.
- Updated e2e tests with `createInstancesByTag` feature.