### PR TITLE
Update ContainerApi.bindToValue to require BindValueOptionsApi

### DIFF
--- a/packages/iocuak/CHANGELOG.md
+++ b/packages/iocuak/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added `BindingTag`.
+- Added `BindValueOptions`.
 - Added `ClassElementMetadata`.
 - Added `ClassElementMetadatType`.
 - Added `ClassElementServiceIdMetadata`.
@@ -34,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated `ContainerModuleMetadata` to allow module classes and modules.
 - Updated `InjectableOptions` with tags.
 - [BC]: Updated `ClassMetadata` to contain `ClassElementMetadata` based properties and constructor arguments.
+- [BC]: Updated `Container.bindToValue` to require `BindValueOptions`.
 
 
 

--- a/packages/iocuak/src/binding/services/api/BindingServiceApi.ts
+++ b/packages/iocuak/src/binding/services/api/BindingServiceApi.ts
@@ -1,12 +1,13 @@
 import { Newable } from '../../../common/models/domain/Newable';
 import { ServiceId } from '../../../common/models/domain/ServiceId';
+import { BindValueOptionsApi } from '../../../container/models/api/BindValueOptionsApi';
 import { BindingApi } from '../../models/api/BindingApi';
 
 export interface BindingServiceApi {
   bind<TInstance, TArgs extends unknown[]>(
     type: Newable<TInstance, TArgs>,
   ): void;
-  bindToValue<TInstance>(serviceId: ServiceId, value: TInstance): void;
+  bindToValue(options: BindValueOptionsApi): void;
   getAllBindinds(): BindingApi[];
   unbind(serviceId: ServiceId): void;
 }

--- a/packages/iocuak/src/container/models/api/BindValueOptionsApi.ts
+++ b/packages/iocuak/src/container/models/api/BindValueOptionsApi.ts
@@ -1,0 +1,8 @@
+import { BindingTag } from '../../../binding/models/domain/BindingTag';
+import { ServiceId } from '../../../common/models/domain/ServiceId';
+
+export interface BindValueOptionsApi {
+  serviceId: ServiceId;
+  tags?: BindingTag | BindingTag[];
+  value: unknown;
+}

--- a/packages/iocuak/src/container/modules/api/ContainerApi.int.spec.ts
+++ b/packages/iocuak/src/container/modules/api/ContainerApi.int.spec.ts
@@ -237,7 +237,10 @@ describe(ContainerApi.name, () => {
 
         containerApi = ContainerApi.build();
 
-        containerApi.bindToValue(serviceIdFixture, valueFixture);
+        containerApi.bindToValue({
+          serviceId: serviceIdFixture,
+          value: valueFixture,
+        });
       });
 
       describe('when called .get()', () => {
@@ -388,10 +391,10 @@ describe(ContainerApi.name, () => {
             load: (
               containerModuleBindingService: ContainerModuleBindingServiceApi,
             ) => {
-              containerModuleBindingService.bindToValue(
-                serviceIdFixture,
+              containerModuleBindingService.bindToValue({
+                serviceId: serviceIdFixture,
                 value,
-              );
+              });
             },
           }),
           imports: [
@@ -400,10 +403,10 @@ describe(ContainerApi.name, () => {
                 load: (
                   containerModuleBindingService: ContainerModuleBindingServiceApi,
                 ) => {
-                  containerModuleBindingService.bindToValue(
-                    dependentServiceIdFixture,
-                    valueFixture,
-                  );
+                  containerModuleBindingService.bindToValue({
+                    serviceId: dependentServiceIdFixture,
+                    value: valueFixture,
+                  });
                 },
               }),
               imports: [],

--- a/packages/iocuak/src/container/services/api/ContainerServiceApiImplementation.spec.ts
+++ b/packages/iocuak/src/container/services/api/ContainerServiceApiImplementation.spec.ts
@@ -106,33 +106,116 @@ describe(ContainerServiceApiImplementation.name, () => {
   });
 
   describe('.bindToValue', () => {
-    describe('when called', () => {
-      let serviceIdFixture: ServiceId;
-      let instanceFixture: unknown;
+    describe('having a tag array', () => {
+      let tagsFixture: BindingTag[];
 
       beforeAll(() => {
-        serviceIdFixture = 'service-id';
-        instanceFixture = {
-          foo: 'bar',
-        };
-
-        containerServiceApiImplementation.bindToValue(
-          serviceIdFixture,
-          instanceFixture,
-        );
+        tagsFixture = [Symbol()];
       });
 
-      afterAll(() => {
-        jest.clearAllMocks();
+      describe('when called', () => {
+        let serviceIdFixture: ServiceId;
+        let instanceFixture: unknown;
+
+        beforeAll(() => {
+          serviceIdFixture = 'service-id';
+          instanceFixture = {
+            foo: 'bar',
+          };
+
+          containerServiceApiImplementation.bindToValue({
+            serviceId: serviceIdFixture,
+            tags: tagsFixture,
+            value: instanceFixture,
+          });
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call bindToValue()', () => {
+          expect(bindToValue).toHaveBeenCalledTimes(1);
+          expect(bindToValue).toHaveBeenCalledWith(
+            serviceIdFixture,
+            tagsFixture,
+            instanceFixture,
+            containerServiceMock.binding,
+          );
+        });
+      });
+    });
+
+    describe('having a tag symbol', () => {
+      let tagsFixture: BindingTag;
+
+      beforeAll(() => {
+        tagsFixture = Symbol();
       });
 
-      it('should call bindToValue()', () => {
-        expect(bindToValue).toHaveBeenCalledTimes(1);
-        expect(bindToValue).toHaveBeenCalledWith(
-          serviceIdFixture,
-          instanceFixture,
-          containerServiceMock.binding,
-        );
+      describe('when called', () => {
+        let serviceIdFixture: ServiceId;
+        let instanceFixture: unknown;
+
+        beforeAll(() => {
+          serviceIdFixture = 'service-id';
+          instanceFixture = {
+            foo: 'bar',
+          };
+
+          containerServiceApiImplementation.bindToValue({
+            serviceId: serviceIdFixture,
+            tags: tagsFixture,
+            value: instanceFixture,
+          });
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call bindToValue()', () => {
+          expect(bindToValue).toHaveBeenCalledTimes(1);
+          expect(bindToValue).toHaveBeenCalledWith(
+            serviceIdFixture,
+            [tagsFixture],
+            instanceFixture,
+            containerServiceMock.binding,
+          );
+        });
+      });
+    });
+
+    describe('having no tags', () => {
+      describe('when called', () => {
+        let serviceIdFixture: ServiceId;
+        let instanceFixture: unknown;
+
+        beforeAll(() => {
+          serviceIdFixture = 'service-id';
+          instanceFixture = {
+            foo: 'bar',
+          };
+
+          containerServiceApiImplementation.bindToValue({
+            serviceId: serviceIdFixture,
+            value: instanceFixture,
+          });
+        });
+
+        afterAll(() => {
+          jest.clearAllMocks();
+        });
+
+        it('should call bindToValue()', () => {
+          expect(bindToValue).toHaveBeenCalledTimes(1);
+          expect(bindToValue).toHaveBeenCalledWith(
+            serviceIdFixture,
+            [],
+            instanceFixture,
+            containerServiceMock.binding,
+          );
+        });
       });
     });
   });

--- a/packages/iocuak/src/container/services/api/ContainerServiceApiImplementation.ts
+++ b/packages/iocuak/src/container/services/api/ContainerServiceApiImplementation.ts
@@ -8,6 +8,7 @@ import { ContainerModuleApi } from '../../../containerModule/models/api/Containe
 import { ContainerModuleMetadataApi } from '../../../containerModuleMetadata/models/api/ContainerModuleMetadataApi';
 import { ContainerModuleMetadata } from '../../../containerModuleMetadata/models/domain/ContainerModuleMetadata';
 import { convertToContainerModuleMetadata } from '../../../containerModuleMetadata/utils/api/convertToContainerModuleMetadata';
+import { BindValueOptionsApi } from '../../models/api/BindValueOptionsApi';
 import { bind } from '../../utils/bind';
 import { bindToValue } from '../../utils/bindToValue';
 import { ContainerService } from '../domain/ContainerService';
@@ -26,8 +27,13 @@ export class ContainerServiceApiImplementation implements ContainerServiceApi {
     bind(type, this._containerService.binding, this._containerService.metadata);
   }
 
-  public bindToValue<TInstance>(serviceId: ServiceId, value: TInstance): void {
-    bindToValue(serviceId, value, this._containerService.binding);
+  public bindToValue(options: BindValueOptionsApi): void {
+    bindToValue(
+      options.serviceId,
+      this.#getTags(options),
+      options.value,
+      this._containerService.binding,
+    );
   }
 
   public get<TInstance>(serviceId: ServiceId): TInstance {
@@ -73,5 +79,19 @@ export class ContainerServiceApiImplementation implements ContainerServiceApi {
   public unbind(serviceId: ServiceId): void {
     this._containerService.singleton.remove(serviceId);
     this._containerService.binding.remove(serviceId);
+  }
+
+  #getTags(options: BindValueOptionsApi): BindingTag[] {
+    const tagOrTags: BindingTag | BindingTag[] = options?.tags ?? [];
+
+    let tags: BindingTag[];
+
+    if (Array.isArray(tagOrTags)) {
+      tags = tagOrTags;
+    } else {
+      tags = [tagOrTags];
+    }
+
+    return tags;
   }
 }

--- a/packages/iocuak/src/container/utils/bindToValue.spec.ts
+++ b/packages/iocuak/src/container/utils/bindToValue.spec.ts
@@ -1,3 +1,6 @@
+import { beforeAll, describe, expect, it, jest } from '@jest/globals';
+import * as jestMock from 'jest-mock';
+
 import { ValueBindingFixtures } from '../../binding/fixtures/domain/ValueBindingFixtures';
 import { ValueBinding } from '../../binding/models/domain/ValueBinding';
 import { BindingService } from '../../binding/services/domain/BindingService';
@@ -6,16 +9,19 @@ import { bindToValue } from '../../container/utils/bindToValue';
 describe(bindToValue.name, () => {
   describe('when called', () => {
     let valueBindingFixture: ValueBinding;
-    let containerBindingServiceMock: jest.Mocked<BindingService>;
+    let containerBindingServiceMock: jestMock.Mocked<BindingService>;
 
     beforeAll(() => {
-      valueBindingFixture = ValueBindingFixtures.withNoTags;
+      valueBindingFixture = ValueBindingFixtures.any;
       containerBindingServiceMock = {
         set: jest.fn(),
-      } as Partial<jest.Mocked<BindingService>> as jest.Mocked<BindingService>;
+      } as Partial<
+        jestMock.Mocked<BindingService>
+      > as jestMock.Mocked<BindingService>;
 
       bindToValue(
         valueBindingFixture.id,
+        valueBindingFixture.tags,
         valueBindingFixture.value,
         containerBindingServiceMock,
       );

--- a/packages/iocuak/src/container/utils/bindToValue.ts
+++ b/packages/iocuak/src/container/utils/bindToValue.ts
@@ -1,3 +1,4 @@
+import { BindingTag } from '../../binding/models/domain/BindingTag';
 import { BindingType } from '../../binding/models/domain/BindingType';
 import { ValueBinding } from '../../binding/models/domain/ValueBinding';
 import { BindingService } from '../../binding/services/domain/BindingService';
@@ -5,13 +6,14 @@ import { ServiceId } from '../../common/models/domain/ServiceId';
 
 export function bindToValue<TInstance>(
   serviceId: ServiceId,
+  tags: BindingTag[],
   value: TInstance,
   containerBindingService: BindingService,
 ): void {
   const valueBinding: ValueBinding<TInstance> = {
     bindingType: BindingType.value,
     id: serviceId,
-    tags: [],
+    tags: [...tags],
     value: value,
   };
 

--- a/packages/iocuak/src/containerModule/utils/api/convertToContainerModule.spec.ts
+++ b/packages/iocuak/src/containerModule/utils/api/convertToContainerModule.spec.ts
@@ -1,6 +1,10 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import * as jestMock from 'jest-mock';
+
 jest.mock('../../../container/utils/bind');
 jest.mock('../../../container/utils/bindToValue');
 
+import { BindingTag } from '../../../binding/models/domain/BindingTag';
 import { BindingService } from '../../../binding/services/domain/BindingService';
 import { Newable } from '../../../common/models/domain/Newable';
 import { ServiceId } from '../../../common/models/domain/ServiceId';
@@ -13,7 +17,7 @@ import { ContainerModule } from '../../models/domain/ContainerModule';
 import { convertToContainerModule } from './convertToContainerModule';
 
 describe(convertToContainerModule.name, () => {
-  let containerModuleApiMock: jest.Mocked<ContainerModuleApi>;
+  let containerModuleApiMock: jestMock.Mocked<ContainerModuleApi>;
 
   beforeAll(() => {
     containerModuleApiMock = {
@@ -63,10 +67,10 @@ describe(convertToContainerModule.name, () => {
         const expected: ContainerModuleBindingServiceApi = {
           bind: expect.any(
             Function,
-          ) as ContainerModuleBindingServiceApi['bind'],
+          ) as unknown as ContainerModuleBindingServiceApi['bind'],
           bindToValue: expect.any(
             Function,
-          ) as ContainerModuleBindingServiceApi['bindToValue'],
+          ) as unknown as ContainerModuleBindingServiceApi['bindToValue'],
         };
 
         expect(containerModuleApiMock.load).toHaveBeenCalledTimes(1);
@@ -111,10 +115,10 @@ describe(convertToContainerModule.name, () => {
         const expected: ContainerModuleBindingServiceApi = {
           bind: expect.any(
             Function,
-          ) as ContainerModuleBindingServiceApi['bind'],
+          ) as unknown as ContainerModuleBindingServiceApi['bind'],
           bindToValue: expect.any(
             Function,
-          ) as ContainerModuleBindingServiceApi['bindToValue'],
+          ) as unknown as ContainerModuleBindingServiceApi['bindToValue'],
         };
 
         expect(containerModuleApiMock.load).toHaveBeenCalledTimes(1);
@@ -133,22 +137,25 @@ describe(convertToContainerModule.name, () => {
 
     describe('when result.load() is called and containerModuleApi.load() calls containerModuleBindingServiceApi.bindToValue()', () => {
       let serviceIdFixture: ServiceId;
+      let tagsFixture: BindingTag[];
       let valueFixture: unknown;
       let containerBindingServiceFixture: BindingService;
       let metadataServiceFixture: MetadataService;
 
       beforeAll(() => {
         serviceIdFixture = Symbol();
+        tagsFixture = [Symbol()];
         valueFixture = Symbol();
 
         containerModuleApiMock.load.mockImplementationOnce(
           (
             containerModuleBindingService: ContainerModuleBindingServiceApi,
           ): void => {
-            containerModuleBindingService.bindToValue(
-              serviceIdFixture,
-              valueFixture,
-            );
+            containerModuleBindingService.bindToValue({
+              serviceId: serviceIdFixture,
+              tags: tagsFixture,
+              value: valueFixture,
+            });
           },
         );
 
@@ -174,10 +181,10 @@ describe(convertToContainerModule.name, () => {
         const expected: ContainerModuleBindingServiceApi = {
           bind: expect.any(
             Function,
-          ) as ContainerModuleBindingServiceApi['bind'],
+          ) as unknown as ContainerModuleBindingServiceApi['bind'],
           bindToValue: expect.any(
             Function,
-          ) as ContainerModuleBindingServiceApi['bindToValue'],
+          ) as unknown as ContainerModuleBindingServiceApi['bindToValue'],
         };
 
         expect(containerModuleApiMock.load).toHaveBeenCalledTimes(1);
@@ -188,6 +195,7 @@ describe(convertToContainerModule.name, () => {
         expect(bindToValue).toHaveBeenCalledTimes(1);
         expect(bindToValue).toHaveBeenCalledWith(
           serviceIdFixture,
+          tagsFixture,
           valueFixture,
           containerBindingServiceFixture,
         );

--- a/packages/iocuak/src/containerModule/utils/api/convertToContainerModule.ts
+++ b/packages/iocuak/src/containerModule/utils/api/convertToContainerModule.ts
@@ -1,6 +1,7 @@
+import { BindingTag } from '../../../binding/models/domain/BindingTag';
 import { BindingService } from '../../../binding/services/domain/BindingService';
 import { Newable } from '../../../common/models/domain/Newable';
-import { ServiceId } from '../../../common/models/domain/ServiceId';
+import { BindValueOptionsApi } from '../../../container/models/api/BindValueOptionsApi';
 import { ContainerModuleBindingServiceApi } from '../../../container/services/api/ContainerModuleBindingServiceApi';
 import { bind } from '../../../container/utils/bind';
 import { bindToValue } from '../../../container/utils/bindToValue';
@@ -21,10 +22,13 @@ export function convertToContainerModule(
           bind: <TInstance, TArgs extends unknown[]>(
             type: Newable<TInstance, TArgs>,
           ) => bind(type, containerBindingService, metadataService),
-          bindToValue: <TInstance>(
-            serviceId: ServiceId,
-            value: TInstance,
-          ): void => bindToValue(serviceId, value, containerBindingService),
+          bindToValue: (options: BindValueOptionsApi): void =>
+            bindToValue(
+              options.serviceId,
+              getTags(options),
+              options.value,
+              containerBindingService,
+            ),
         };
 
       containerModuleApi.load(containerModuleBindingServiceApi);
@@ -32,4 +36,18 @@ export function convertToContainerModule(
   };
 
   return containerModule;
+}
+
+function getTags(options: BindValueOptionsApi): BindingTag[] {
+  const tagOrTags: BindingTag | BindingTag[] = options?.tags ?? [];
+
+  let tags: BindingTag[];
+
+  if (Array.isArray(tagOrTags)) {
+    tags = tagOrTags;
+  } else {
+    tags = [tagOrTags];
+  }
+
+  return tags;
 }

--- a/packages/iocuak/src/e2e/definitions/container/containerDefinitions.ts
+++ b/packages/iocuak/src/e2e/definitions/container/containerDefinitions.ts
@@ -407,7 +407,7 @@ When<ContainerWorld & TypeServiceWorld>(
   },
 );
 
-When<ResultWorld & TagWorld & TypeServiceWorld>(
+When<TagWorld & TypeServiceWorld>(
   'the type binding is updated to include the tag',
   function (): void {
     const service: Newable = this.typeServiceParameter.service;
@@ -439,6 +439,7 @@ When<ContainerWorld & ValueServiceWorld>(
   function (): void {
     this.container.bindToValue({
       serviceId: this.valueServiceParameter.binding.id,
+      tags: [...this.valueServiceParameter.binding.tags],
       value: this.valueServiceParameter.service,
     });
   },
@@ -448,6 +449,17 @@ When<ContainerWorld & ValueServiceWorld>(
   'the value service is unbound',
   function (): void {
     this.container.unbind(this.valueServiceParameter.binding.id);
+  },
+);
+
+When<ContainerWorld & TagWorld & ValueServiceWorld>(
+  'the value service is bound to the tag',
+  function (): void {
+    this.container.bindToValue({
+      serviceId: this.valueServiceParameter.binding.id,
+      tags: [...this.valueServiceParameter.binding.tags, this.tag],
+      value: this.valueServiceParameter.service,
+    });
   },
 );
 
@@ -465,6 +477,21 @@ Then<ResultWorld & TypeServiceWorld>(
       const [instance]: unknown[] = this.result as unknown[];
 
       chai.expect(instance).to.be.instanceOf(this.typeServiceParameter.service);
+    } else {
+      throw new Error('Expected an array result');
+    }
+  },
+);
+
+Then<ResultWorld & ValueServiceWorld>(
+  'an array with the value service is returned',
+  function (): void {
+    if (Array.isArray(this.result)) {
+      const [instance]: unknown[] = this.result as unknown[];
+
+      chai
+        .expect(instance)
+        .to.be.equal(this.valueServiceParameter.binding.value);
     } else {
       throw new Error('Expected an array result');
     }

--- a/packages/iocuak/src/e2e/definitions/container/containerDefinitions.ts
+++ b/packages/iocuak/src/e2e/definitions/container/containerDefinitions.ts
@@ -78,10 +78,10 @@ function bindServiceDependencies(
 
           break;
         case BindingTypeApi.value:
-          this.container.bindToValue(
-            dependency.binding.id,
-            (dependency as ValueServiceParameter).binding.value,
-          );
+          this.container.bindToValue({
+            serviceId: dependency.binding.id,
+            value: (dependency as ValueServiceParameter).binding.value,
+          });
           break;
       }
     }
@@ -437,10 +437,10 @@ When<ContainerWorld & ResultWorld & TypeServiceWorld>(
 When<ContainerWorld & ValueServiceWorld>(
   'the value service is bound',
   function (): void {
-    this.container.bindToValue(
-      this.valueServiceParameter.binding.id,
-      this.valueServiceParameter.service,
-    );
+    this.container.bindToValue({
+      serviceId: this.valueServiceParameter.binding.id,
+      value: this.valueServiceParameter.service,
+    });
   },
 );
 

--- a/packages/iocuak/src/e2e/definitions/container/parameters/containerModule/getContainerModuleWithTypeServiceAndValueServiceParameter.ts
+++ b/packages/iocuak/src/e2e/definitions/container/parameters/containerModule/getContainerModuleWithTypeServiceAndValueServiceParameter.ts
@@ -24,10 +24,10 @@ export function getContainerModuleWithTypeServiceAndValueServiceParameter(): Con
       loadSpy(containerModuleBindingServiceApi);
 
       containerModuleBindingServiceApi.bind(typeServiceParameter.service);
-      containerModuleBindingServiceApi.bindToValue(
-        valueServiceParameter.binding.id,
-        valueServiceParameter.binding.value,
-      );
+      containerModuleBindingServiceApi.bindToValue({
+        serviceId: valueServiceParameter.binding.id,
+        value: valueServiceParameter.binding.value,
+      });
     },
   };
 

--- a/packages/iocuak/src/e2e/features/container/createInstancesByTag.feature
+++ b/packages/iocuak/src/e2e/features/container/createInstancesByTag.feature
@@ -8,7 +8,13 @@ Feature: Create instances by tag
 
   Rule: Any bound type service is instantiated
 
-    Scenario Outline: Bound value service request
+    Scenario: Bound value service request
+      Given a "value service"
+      When the value service is bound to the tag
+      And instaces by tag are requested
+      Then an array with the value service is returned
+
+    Scenario Outline: Bound type service request
       Given a <type_service>
       When the type binding is updated to include the tag
       And the type service dependencies are bound

--- a/packages/iocuak/src/index.ts
+++ b/packages/iocuak/src/index.ts
@@ -12,6 +12,7 @@ import { injectFromBase } from './classMetadata/decorators/injectFromBase';
 import { ClassMetadataApi } from './classMetadata/models/api/ClassMetadataApi';
 import { Newable } from './common/models/domain/Newable';
 import { ServiceId } from './common/models/domain/ServiceId';
+import { BindValueOptionsApi } from './container/models/api/BindValueOptionsApi';
 import { ContainerApi } from './container/modules/api/ContainerApi';
 import { ContainerModuleBindingServiceApi } from './container/services/api/ContainerModuleBindingServiceApi';
 import { ContainerServiceApi } from './container/services/api/ContainerServiceApi';
@@ -24,6 +25,7 @@ export type {
   BindingApi as Binding,
   BindingTag,
   BindingTypeApi as BindingType,
+  BindValueOptionsApi as BindValueOptions,
   ClassMetadataApi as ClassMetadata,
   ContainerModuleMetadataApi as ContainerModuleMetadata,
   ContainerModuleApi as ContainerModule,

--- a/packages/porygon-typeorm/CHANGELOG.md
+++ b/packages/porygon-typeorm/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
+## [UNRELEASED]
+
+### Changed
+- Bumped `@cuaklabs/porygon` version
+
+
+
+
 ## 0.1.1 - 2022-03-08
 
 ### Fixed

--- a/packages/porygon-typeorm/src/crud/modules/iocuak/TypeOrmCreateContainerModule.int.spec.ts
+++ b/packages/porygon-typeorm/src/crud/modules/iocuak/TypeOrmCreateContainerModule.int.spec.ts
@@ -112,10 +112,11 @@ describe(TypeOrmCreateContainerModule.name, () => {
 
         containerApi = Container.build();
 
-        containerApi.bindToValue(
-          crudTypeOrmModuleTypeToSymbolMap[CrudTypeOrmModuleType.repository],
-          {},
-        );
+        containerApi.bindToValue({
+          serviceId:
+            crudTypeOrmModuleTypeToSymbolMap[CrudTypeOrmModuleType.repository],
+          value: {},
+        });
         containerApi.bind(modelDbToModelConverterType);
         containerApi.bind(insertQueryToSetTypeOrmQueryConverterType);
       });

--- a/packages/porygon-typeorm/src/crud/modules/iocuak/TypeOrmCrudContainerModule.spec.ts
+++ b/packages/porygon-typeorm/src/crud/modules/iocuak/TypeOrmCrudContainerModule.spec.ts
@@ -148,12 +148,13 @@ describe(TypeOrmCrudContainerModule.name, () => {
 
         it('should call container.bindToValue()', () => {
           expect(containerApiMock.bindToValue).toHaveBeenCalledTimes(1);
-          expect(containerApiMock.bindToValue).toHaveBeenCalledWith(
-            crudTypeOrmModuleTypeToSymbolMapFixture[
-              CrudTypeOrmModuleType.repository
-            ],
-            repositoryMock,
-          );
+          expect(containerApiMock.bindToValue).toHaveBeenCalledWith({
+            serviceId:
+              crudTypeOrmModuleTypeToSymbolMapFixture[
+                CrudTypeOrmModuleType.repository
+              ],
+            value: repositoryMock,
+          });
         });
 
         it('should call TypeOrmCreateContainerModule.load()', () => {

--- a/packages/porygon-typeorm/src/crud/modules/iocuak/TypeOrmCrudContainerModule.ts
+++ b/packages/porygon-typeorm/src/crud/modules/iocuak/TypeOrmCrudContainerModule.ts
@@ -66,10 +66,13 @@ export class TypeOrmCrudContainerModule<TModelDb>
   public load(
     containerModuleBindingService: iocuak.ContainerModuleBindingService,
   ): void {
-    containerModuleBindingService.bindToValue(
-      this.#crudTypeOrmModuleTypeToSymbolMap[CrudTypeOrmModuleType.repository],
-      this.#repository,
-    );
+    containerModuleBindingService.bindToValue({
+      serviceId:
+        this.#crudTypeOrmModuleTypeToSymbolMap[
+          CrudTypeOrmModuleType.repository
+        ],
+      value: this.#repository,
+    });
 
     this.#typeOrmCreationContainerModule.load(containerModuleBindingService);
     this.#typeOrmDeleteContainerModule.load(containerModuleBindingService);

--- a/packages/porygon-typeorm/src/crud/modules/iocuak/TypeOrmDeleteContainerModule.int.spec.ts
+++ b/packages/porygon-typeorm/src/crud/modules/iocuak/TypeOrmDeleteContainerModule.int.spec.ts
@@ -104,10 +104,11 @@ describe(TypeOrmDeleteContainerModule.name, () => {
 
         containerApi = Container.build();
 
-        containerApi.bindToValue(
-          crudTypeOrmModuleTypeToSymbolMap[CrudTypeOrmModuleType.repository],
-          {},
-        );
+        containerApi.bindToValue({
+          serviceId:
+            crudTypeOrmModuleTypeToSymbolMap[CrudTypeOrmModuleType.repository],
+          value: {},
+        });
         containerApi.bind(findQueryToFindQueryTypeOrmConverterType);
       });
 

--- a/packages/porygon-typeorm/src/crud/modules/iocuak/TypeOrmReadContainerModule.int.spec.ts
+++ b/packages/porygon-typeorm/src/crud/modules/iocuak/TypeOrmReadContainerModule.int.spec.ts
@@ -112,10 +112,11 @@ describe(TypeOrmReadContainerModule.name, () => {
 
         containerApi = Container.build();
 
-        containerApi.bindToValue(
-          crudTypeOrmModuleTypeToSymbolMap[CrudTypeOrmModuleType.repository],
-          {},
-        );
+        containerApi.bindToValue({
+          serviceId:
+            crudTypeOrmModuleTypeToSymbolMap[CrudTypeOrmModuleType.repository],
+          value: {},
+        });
         containerApi.bind(modelDbToModelConverterType);
         containerApi.bind(findQueryToFindQueryTypeOrmConverterType);
       });

--- a/packages/porygon-typeorm/src/crud/modules/iocuak/TypeOrmUpdateContainerModule.int.spec.ts
+++ b/packages/porygon-typeorm/src/crud/modules/iocuak/TypeOrmUpdateContainerModule.int.spec.ts
@@ -111,10 +111,11 @@ describe(TypeOrmUpdateContainerModule.name, () => {
 
         containerApi = Container.build();
 
-        containerApi.bindToValue(
-          crudTypeOrmModuleTypeToSymbolMap[CrudTypeOrmModuleType.repository],
-          {},
-        );
+        containerApi.bindToValue({
+          serviceId:
+            crudTypeOrmModuleTypeToSymbolMap[CrudTypeOrmModuleType.repository],
+          value: {},
+        });
         containerApi.bind(updateQueryToFindQueryTypeOrmConverterType);
         containerApi.bind(updateQueryToSetQueryTypeOrmQueryConverterType);
       });

--- a/packages/porygon/CHANGELOG.md
+++ b/packages/porygon/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
+## [UNRELEASED]
+
+### Changed
+- Bumped `@cuaklabs/iocuak` version
+
+
+
+
 ## 0.1.1 - 2022-03-08
 
 ### Fixed


### PR DESCRIPTION
### Added
- IOC-78: Added `BindValueOptionsApi`.

### Changed
- IOC-79: Updated `ContainerApi.bindToValue` to require `BindValueOptionsApi`.
- IOC-80: Updated `bindToValue` to receive a `tags` array.
- IOC-81: Updated createByTag feature with value binding related test