### PR TITLE
Release cuaktask@0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prebuild": "pnpm run build:clean",
     "prebuild:diagnostics": "pnpm run prebuild",
     "prepare": "husky install",
-    "prepublish:packages": "pnpm run build && pnpm run test",
+    "prepublish:packages": "pnpm run build && pnpm run test:js && pnpm run test:e2e:js",
     "test:coverage": "pnpm run test --coverage",
     "test:e2e": "cucumber-js --config=config/cucumber/cucumber.ts.config.mjs",
     "test:e2e:js": "cucumber-js --config=config/cucumber/cucumber.js.config.mjs",

--- a/packages/cuaktask/CHANGELOG.md
+++ b/packages/cuaktask/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 
-## [UNRELEASED]
+## 0.3.0 - 2022-06-28
 
 ### Added
 - Added `AndNodeDependencies`.

--- a/packages/cuaktask/package.json
+++ b/packages/cuaktask/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuaklabs/cuaktask",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Minimal abstract task manager",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
## 0.3.0 - 2022-06-28

### Added
- Added `AndNodeDependencies`.
- Added `Graph`.
- Added `Node`.
- Added `NodeDependencies`.
- Added `NodeDependency`.
- Added `BitwiseOrNodeDependencies`.
- Added `RootedGraph`.
- Added `RootedTaskGraphRunner`.
- Added `TaskGraphEngine`.

### Changed
- Updated `BaseTask` with protected `_setErrorStatus` method.
