### PR TITLE
Add load container metadata functional modules

### DIFF
--- a/packages/iocuak/src/task/actions/domain/loadContainerModule.spec.ts
+++ b/packages/iocuak/src/task/actions/domain/loadContainerModule.spec.ts
@@ -1,0 +1,136 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import * as jestMock from 'jest-mock';
+
+jest.mock('./loadContainerModuleElement');
+jest.mock('./loadContainerModuleElementAsync');
+
+import { ContainerModule } from '../../../containerModule/models/domain/ContainerModule';
+import { ContainerModuleMetadata } from '../../../containerModuleMetadata/models/domain/ContainerModuleMetadata';
+import { ContainerModuleMetadataType } from '../../../containerModuleMetadata/models/domain/ContainerModuleMetadataType';
+import { TaskContext } from '../../models/domain/TaskContext';
+import { loadContainerModule } from './loadContainerModule';
+import { loadContainerModuleElement } from './loadContainerModuleElement';
+import { loadContainerModuleElementAsync } from './loadContainerModuleElementAsync';
+
+describe(loadContainerModule.name, () => {
+  describe('having a sync ContainerModuleMetadata with no dependencies', () => {
+    let containerModuleMock: jestMock.Mocked<ContainerModule>;
+    let containerModuleMetadataFixture: ContainerModuleMetadata;
+
+    beforeAll(() => {
+      containerModuleMock = {
+        load: jest.fn(),
+      };
+
+      containerModuleMetadataFixture = {
+        factory: () => containerModuleMock,
+        imports: [],
+        injects: [],
+        type: ContainerModuleMetadataType.factory,
+      };
+    });
+
+    describe('when called', () => {
+      let taskContextFixture: TaskContext;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        taskContextFixture = {
+          [Symbol()]: Symbol(),
+        } as unknown as TaskContext;
+
+        result = loadContainerModule(
+          containerModuleMetadataFixture,
+          taskContextFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call loadContainerModuleElement()', () => {
+        expect(loadContainerModuleElement).toHaveBeenCalledTimes(1);
+        expect(loadContainerModuleElement).toHaveBeenCalledWith(
+          containerModuleMetadataFixture,
+          taskContextFixture,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a ContainerModuleMetadata with async dependencies', () => {
+    let containerModuleMock: jestMock.Mocked<ContainerModule>;
+    let containerModuleMetadataFixture: ContainerModuleMetadata;
+
+    beforeAll(() => {
+      containerModuleMock = {
+        load: jest.fn(),
+      };
+
+      containerModuleMetadataFixture = {
+        factory: () => containerModuleMock,
+        imports: [
+          {
+            factory: () => containerModuleMock,
+            imports: [],
+            injects: [],
+            type: ContainerModuleMetadataType.factory,
+          },
+        ],
+        injects: [],
+        type: ContainerModuleMetadataType.factory,
+      };
+    });
+
+    describe('when called', () => {
+      let taskContextFixture: TaskContext;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        taskContextFixture = {
+          [Symbol()]: Symbol(),
+        } as unknown as TaskContext;
+
+        (
+          loadContainerModuleElement as jestMock.Mock<() => Promise<void>>
+        ).mockResolvedValueOnce(undefined);
+
+        result = loadContainerModule(
+          containerModuleMetadataFixture,
+          taskContextFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call loadContainerModuleElement()', () => {
+        expect(loadContainerModuleElement).toHaveBeenCalledTimes(1);
+        expect(loadContainerModuleElement).toHaveBeenCalledWith(
+          containerModuleMetadataFixture.imports[0],
+          taskContextFixture,
+        );
+      });
+
+      it('should call loadContainerModuleElementAsync()', () => {
+        expect(loadContainerModuleElementAsync).toHaveBeenCalledWith(
+          containerModuleMetadataFixture,
+          taskContextFixture,
+          Promise.resolve(undefined),
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});

--- a/packages/iocuak/src/task/actions/domain/loadContainerModule.ts
+++ b/packages/iocuak/src/task/actions/domain/loadContainerModule.ts
@@ -1,0 +1,57 @@
+import * as cuaktask from '@cuaklabs/cuaktask';
+
+import { ContainerModuleMetadata } from '../../../containerModuleMetadata/models/domain/ContainerModuleMetadata';
+import { TaskContext } from '../../models/domain/TaskContext';
+import { loadContainerModuleElement } from './loadContainerModuleElement';
+import { loadContainerModuleElementAsync } from './loadContainerModuleElementAsync';
+
+export function loadContainerModule(
+  containerModuleMetadata: ContainerModuleMetadata,
+  context: TaskContext,
+): void | Promise<void> {
+  const loadModuleDependenciesResult: void | Promise<void> =
+    loadContainerModuleDependencies(containerModuleMetadata, context);
+
+  let loadContainerModuleResult: void | Promise<void>;
+
+  if (cuaktask.isPromiseLike(loadModuleDependenciesResult)) {
+    loadContainerModuleResult = loadContainerModuleElementAsync(
+      containerModuleMetadata,
+      context,
+      loadModuleDependenciesResult,
+    );
+  } else {
+    loadContainerModuleResult = loadContainerModuleElement(
+      containerModuleMetadata,
+      context,
+    );
+  }
+
+  return loadContainerModuleResult;
+}
+
+function loadContainerModuleDependencies(
+  containerModuleMetadata: ContainerModuleMetadata,
+  context: TaskContext,
+): void | Promise<void> {
+  const asyncResults: Promise<void>[] = [];
+
+  for (const containerModuleMetadataDependency of containerModuleMetadata.imports) {
+    const loadContainerModuleResult: void | Promise<void> = loadContainerModule(
+      containerModuleMetadataDependency,
+      context,
+    );
+
+    if (cuaktask.isPromiseLike(loadContainerModuleResult)) {
+      asyncResults.push(loadContainerModuleResult);
+    }
+  }
+
+  if (asyncResults.length !== 0) {
+    return toVoidPromise(Promise.all(asyncResults));
+  }
+}
+
+async function toVoidPromise(input: Promise<unknown>): Promise<void> {
+  await input;
+}

--- a/packages/iocuak/src/task/actions/domain/loadContainerModuleElement.spec.ts
+++ b/packages/iocuak/src/task/actions/domain/loadContainerModuleElement.spec.ts
@@ -1,0 +1,97 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('./loadFromContainerModuleClassMetadata');
+jest.mock('./loadFromContainerModuleFactoryMetadata');
+
+import { ContainerModuleMetadata } from '../../../containerModuleMetadata/models/domain/ContainerModuleMetadata';
+import { ContainerModuleMetadataMocks } from '../../../containerModuleTask/mocks/models/domain/ContainerModuleMetadataMocks';
+import { TaskContext } from '../../models/domain/TaskContext';
+import { loadContainerModuleElement } from './loadContainerModuleElement';
+import { loadFromContainerModuleClassMetadata } from './loadFromContainerModuleClassMetadata';
+import { loadFromContainerModuleFactoryMetadata } from './loadFromContainerModuleFactoryMetadata';
+
+describe(loadContainerModuleElement.name, () => {
+  describe('having a ContainerModuleMetadata of type class', () => {
+    let containerModuleMetadataFixture: ContainerModuleMetadata;
+
+    beforeAll(() => {
+      containerModuleMetadataFixture =
+        ContainerModuleMetadataMocks.withTypeClazz;
+    });
+
+    describe('when called', () => {
+      let taskContextFixture: TaskContext;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        taskContextFixture = {
+          [Symbol()]: Symbol(),
+        } as unknown as TaskContext;
+
+        result = loadContainerModuleElement(
+          containerModuleMetadataFixture,
+          taskContextFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call loadFromContainerModuleClassMetadata()', () => {
+        expect(loadFromContainerModuleClassMetadata).toHaveBeenCalledTimes(1);
+        expect(loadFromContainerModuleClassMetadata).toHaveBeenCalledWith(
+          containerModuleMetadataFixture,
+          taskContextFixture,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a ContainerModuleMetadata of type factory', () => {
+    let containerModuleMetadataFixture: ContainerModuleMetadata;
+
+    beforeAll(() => {
+      containerModuleMetadataFixture =
+        ContainerModuleMetadataMocks.withTypeFactory;
+    });
+
+    describe('when called', () => {
+      let taskContextFixture: TaskContext;
+
+      let result: unknown;
+
+      beforeAll(() => {
+        taskContextFixture = {
+          [Symbol()]: Symbol(),
+        } as unknown as TaskContext;
+
+        result = loadContainerModuleElement(
+          containerModuleMetadataFixture,
+          taskContextFixture,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call loadFromContainerModuleFactoryMetadata()', () => {
+        expect(loadFromContainerModuleFactoryMetadata).toHaveBeenCalledTimes(1);
+        expect(loadFromContainerModuleFactoryMetadata).toHaveBeenCalledWith(
+          containerModuleMetadataFixture,
+          taskContextFixture,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});

--- a/packages/iocuak/src/task/actions/domain/loadContainerModuleElement.ts
+++ b/packages/iocuak/src/task/actions/domain/loadContainerModuleElement.ts
@@ -1,0 +1,29 @@
+import { ContainerModuleMetadata } from '../../../containerModuleMetadata/models/domain/ContainerModuleMetadata';
+import { ContainerModuleMetadataType } from '../../../containerModuleMetadata/models/domain/ContainerModuleMetadataType';
+import { TaskContext } from '../../models/domain/TaskContext';
+import { loadFromContainerModuleClassMetadata } from './loadFromContainerModuleClassMetadata';
+import { loadFromContainerModuleFactoryMetadata } from './loadFromContainerModuleFactoryMetadata';
+
+export function loadContainerModuleElement(
+  containerModuleMetadata: ContainerModuleMetadata,
+  context: TaskContext,
+): void | Promise<void> {
+  let loadContainerModuleResult: void | Promise<void>;
+
+  switch (containerModuleMetadata.type) {
+    case ContainerModuleMetadataType.factory:
+      loadContainerModuleResult = loadFromContainerModuleFactoryMetadata(
+        containerModuleMetadata,
+        context,
+      );
+      break;
+    case ContainerModuleMetadataType.clazz:
+      loadContainerModuleResult = loadFromContainerModuleClassMetadata(
+        containerModuleMetadata,
+        context,
+      );
+      break;
+  }
+
+  return loadContainerModuleResult;
+}

--- a/packages/iocuak/src/task/actions/domain/loadContainerModuleElementAsync.spec.ts
+++ b/packages/iocuak/src/task/actions/domain/loadContainerModuleElementAsync.spec.ts
@@ -1,0 +1,52 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('./loadContainerModuleElement');
+
+import { ContainerModuleMetadata } from '../../../containerModuleMetadata/models/domain/ContainerModuleMetadata';
+import { TaskContext } from '../../models/domain/TaskContext';
+import { loadContainerModuleElement } from './loadContainerModuleElement';
+import { loadContainerModuleElementAsync } from './loadContainerModuleElementAsync';
+
+describe(loadContainerModuleElementAsync.name, () => {
+  describe('when called', () => {
+    let containerModuleMetadataFixture: ContainerModuleMetadata;
+    let taskContextFixture: TaskContext;
+    let loadModuleDependenciesResultFixture: Promise<void>;
+
+    let result: unknown;
+
+    beforeAll(async () => {
+      containerModuleMetadataFixture = {
+        [Symbol()]: Symbol(),
+      } as unknown as ContainerModuleMetadata;
+
+      taskContextFixture = {
+        [Symbol()]: Symbol(),
+      } as unknown as TaskContext;
+
+      loadModuleDependenciesResultFixture = Promise.resolve();
+
+      result = await loadContainerModuleElementAsync(
+        containerModuleMetadataFixture,
+        taskContextFixture,
+        loadModuleDependenciesResultFixture,
+      );
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call loadContainerModuleElement()', () => {
+      expect(loadContainerModuleElement).toHaveBeenCalledTimes(1);
+      expect(loadContainerModuleElement).toHaveBeenCalledWith(
+        containerModuleMetadataFixture,
+        taskContextFixture,
+      );
+    });
+
+    it('should return undefined', () => {
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/iocuak/src/task/actions/domain/loadContainerModuleElementAsync.ts
+++ b/packages/iocuak/src/task/actions/domain/loadContainerModuleElementAsync.ts
@@ -1,0 +1,13 @@
+import { ContainerModuleMetadata } from '../../../containerModuleMetadata/models/domain/ContainerModuleMetadata';
+import { TaskContext } from '../../models/domain/TaskContext';
+import { loadContainerModuleElement } from './loadContainerModuleElement';
+
+export async function loadContainerModuleElementAsync(
+  containerModuleMetadata: ContainerModuleMetadata,
+  context: TaskContext,
+  loadModuleDependenciesResult: Promise<void>,
+): Promise<void> {
+  await loadModuleDependenciesResult;
+
+  return loadContainerModuleElement(containerModuleMetadata, context);
+}

--- a/packages/iocuak/src/task/actions/domain/loadFromContainerModuleClassMetadata.spec.ts
+++ b/packages/iocuak/src/task/actions/domain/loadFromContainerModuleClassMetadata.spec.ts
@@ -1,0 +1,75 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import * as jestMock from 'jest-mock';
+
+jest.mock('./createInstance');
+
+import { BindingService } from '../../../binding/services/domain/BindingService';
+import { ContainerModuleClassMetadata } from '../../../containerModuleMetadata/models/domain/ContainerModuleClassMetadata';
+import { MetadataService } from '../../../metadata/services/domain/MetadataService';
+import { TaskContext } from '../../models/domain/TaskContext';
+import { TaskContextServices } from '../../models/domain/TaskContextServices';
+import { createInstance } from './createInstance';
+import { loadFromContainerModuleClassMetadata } from './loadFromContainerModuleClassMetadata';
+
+describe(loadFromContainerModuleClassMetadata.name, () => {
+  let containerModuleClassMetadataMock: ContainerModuleClassMetadata;
+  let taskContextMock: TaskContext;
+
+  beforeAll(() => {
+    containerModuleClassMetadataMock = {
+      loader: jest.fn(),
+      moduleType: jest.fn(),
+    } as Partial<ContainerModuleClassMetadata> as ContainerModuleClassMetadata;
+
+    taskContextMock = {
+      services: {
+        bindingService: { [Symbol()]: Symbol() } as unknown as BindingService,
+        metadataService: { [Symbol()]: Symbol() } as unknown as MetadataService,
+      } as Partial<TaskContextServices> as TaskContextServices,
+    } as Partial<TaskContext> as TaskContext;
+  });
+
+  describe('when called', () => {
+    let containerModuleInstanceFixture: unknown;
+
+    let result: unknown;
+
+    beforeAll(() => {
+      containerModuleInstanceFixture = Symbol();
+
+      (
+        createInstance as jestMock.Mock<typeof createInstance>
+      ).mockReturnValueOnce(containerModuleInstanceFixture);
+
+      result = loadFromContainerModuleClassMetadata(
+        containerModuleClassMetadataMock,
+        taskContextMock,
+      );
+    });
+
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call createInstance()', () => {
+      expect(createInstance).toHaveBeenCalledTimes(1);
+      expect(createInstance).toHaveBeenCalledWith(
+        containerModuleClassMetadataMock.moduleType,
+        taskContextMock,
+      );
+    });
+
+    it('should call containerModuleClassMetadata.loader()', () => {
+      expect(containerModuleClassMetadataMock.loader).toHaveBeenCalledTimes(1);
+      expect(containerModuleClassMetadataMock.loader).toHaveBeenCalledWith(
+        containerModuleInstanceFixture,
+        taskContextMock.services.bindingService,
+        taskContextMock.services.metadataService,
+      );
+    });
+
+    it('should return undefined', () => {
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/iocuak/src/task/actions/domain/loadFromContainerModuleClassMetadata.ts
+++ b/packages/iocuak/src/task/actions/domain/loadFromContainerModuleClassMetadata.ts
@@ -1,0 +1,34 @@
+import { BindingService } from '../../../binding/services/domain/BindingService';
+import { ContainerModule } from '../../../containerModule/models/domain/ContainerModule';
+import { ContainerModuleClassMetadata } from '../../../containerModuleMetadata/models/domain/ContainerModuleClassMetadata';
+import { MetadataService } from '../../../metadata/services/domain/MetadataService';
+import { TaskContext } from '../../models/domain/TaskContext';
+import { createInstance } from './createInstance';
+
+export function loadFromContainerModuleClassMetadata(
+  metadata: ContainerModuleClassMetadata,
+  context: TaskContext,
+): void {
+  const containerModuleFromMetadata: unknown = createInstance(
+    metadata.moduleType,
+    context,
+  );
+
+  const containerModule: ContainerModule = {
+    load: (
+      containerBindingService: BindingService,
+      metadataService: MetadataService,
+    ): void => {
+      metadata.loader(
+        containerModuleFromMetadata,
+        containerBindingService,
+        metadataService,
+      );
+    },
+  };
+
+  containerModule.load(
+    context.services.bindingService,
+    context.services.metadataService,
+  );
+}

--- a/packages/iocuak/src/task/actions/domain/loadFromContainerModuleFactoryMetadata.spec.ts
+++ b/packages/iocuak/src/task/actions/domain/loadFromContainerModuleFactoryMetadata.spec.ts
@@ -1,0 +1,210 @@
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import * as jestMock from 'jest-mock';
+
+jest.mock('./createInstance');
+
+import { BindingService } from '../../../binding/services/domain/BindingService';
+import { ContainerModule } from '../../../containerModule/models/domain/ContainerModule';
+import { ContainerModuleFactoryMetadata } from '../../../containerModuleMetadata/models/domain/ContainerModuleFactoryMetadata';
+import { ContainerModuleMetadataType } from '../../../containerModuleMetadata/models/domain/ContainerModuleMetadataType';
+import { MetadataService } from '../../../metadata/services/domain/MetadataService';
+import { TaskContext } from '../../models/domain/TaskContext';
+import { TaskContextServices } from '../../models/domain/TaskContextServices';
+import { createInstance } from './createInstance';
+import { loadFromContainerModuleFactoryMetadata } from './loadFromContainerModuleFactoryMetadata';
+
+describe(loadFromContainerModuleFactoryMetadata.name, () => {
+  describe('having a ContainerModuleFactoryMetadata with an async factory', () => {
+    let containerModuleFactoryMetadataFactoryMock: jestMock.Mock<
+      () => Promise<ContainerModule>
+    >;
+    let containerModuleFactoryMetadataMock: ContainerModuleFactoryMetadata;
+
+    beforeAll(() => {
+      containerModuleFactoryMetadataFactoryMock =
+        jest.fn<() => Promise<ContainerModule>>();
+
+      containerModuleFactoryMetadataMock = {
+        factory: containerModuleFactoryMetadataFactoryMock,
+        imports: [],
+        injects: [Symbol()],
+        type: ContainerModuleMetadataType.factory,
+      };
+    });
+
+    describe('when called', () => {
+      let taskContextMock: TaskContext;
+      let containerModuleMock: jestMock.Mocked<ContainerModule>;
+      let factoryParameterFixture: unknown;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        taskContextMock = {
+          services: {
+            bindingService: {
+              [Symbol()]: Symbol(),
+            } as unknown as BindingService,
+            metadataService: {
+              [Symbol()]: Symbol(),
+            } as unknown as MetadataService,
+          } as Partial<TaskContextServices> as TaskContextServices,
+        } as Partial<TaskContext> as TaskContext;
+
+        containerModuleMock = {
+          load: jest.fn(),
+        };
+
+        factoryParameterFixture = Symbol();
+
+        (
+          createInstance as jestMock.Mock<typeof createInstance>
+        ).mockReturnValueOnce(factoryParameterFixture);
+
+        containerModuleFactoryMetadataFactoryMock.mockResolvedValueOnce(
+          containerModuleMock,
+        );
+
+        result = await loadFromContainerModuleFactoryMetadata(
+          containerModuleFactoryMetadataMock,
+          taskContextMock,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call createInstance()', () => {
+        const expectedTaskContext: TaskContext = {
+          ...taskContextMock,
+          servicesInstantiatedSet: new Set(),
+        };
+
+        expect(createInstance).toHaveBeenCalledTimes(1);
+        expect(createInstance).toHaveBeenCalledWith(
+          containerModuleFactoryMetadataMock.injects[0],
+          expectedTaskContext,
+        );
+      });
+
+      it('should call containerModuleFactoryMetadata.factory()', () => {
+        expect(
+          containerModuleFactoryMetadataMock.factory,
+        ).toHaveBeenCalledTimes(1);
+        expect(containerModuleFactoryMetadataMock.factory).toHaveBeenCalledWith(
+          factoryParameterFixture,
+        );
+      });
+
+      it('should call containerModule.load()', () => {
+        expect(containerModuleMock.load).toHaveBeenCalledTimes(1);
+        expect(containerModuleMock.load).toHaveBeenCalledWith(
+          taskContextMock.services.bindingService,
+          taskContextMock.services.metadataService,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('having a ContainerModuleFactoryMetadata with a sync factory', () => {
+    let containerModuleFactoryMetadataFactoryMock: jestMock.Mock<
+      () => ContainerModule
+    >;
+    let containerModuleFactoryMetadataMock: ContainerModuleFactoryMetadata;
+
+    beforeAll(() => {
+      containerModuleFactoryMetadataFactoryMock =
+        jest.fn<() => ContainerModule>();
+
+      containerModuleFactoryMetadataMock = {
+        factory: containerModuleFactoryMetadataFactoryMock,
+        imports: [],
+        injects: [Symbol()],
+        type: ContainerModuleMetadataType.factory,
+      };
+    });
+
+    describe('when called', () => {
+      let taskContextMock: TaskContext;
+      let containerModuleMock: jestMock.Mocked<ContainerModule>;
+      let factoryParameterFixture: unknown;
+
+      let result: unknown;
+
+      beforeAll(async () => {
+        taskContextMock = {
+          services: {
+            bindingService: {
+              [Symbol()]: Symbol(),
+            } as unknown as BindingService,
+            metadataService: {
+              [Symbol()]: Symbol(),
+            } as unknown as MetadataService,
+          } as Partial<TaskContextServices> as TaskContextServices,
+        } as Partial<TaskContext> as TaskContext;
+
+        containerModuleMock = {
+          load: jest.fn(),
+        };
+
+        factoryParameterFixture = Symbol();
+
+        (
+          createInstance as jestMock.Mock<typeof createInstance>
+        ).mockReturnValueOnce(factoryParameterFixture);
+
+        containerModuleFactoryMetadataFactoryMock.mockReturnValueOnce(
+          containerModuleMock,
+        );
+
+        result = await loadFromContainerModuleFactoryMetadata(
+          containerModuleFactoryMetadataMock,
+          taskContextMock,
+        );
+      });
+
+      afterAll(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call createInstance()', () => {
+        const expectedTaskContext: TaskContext = {
+          ...taskContextMock,
+          servicesInstantiatedSet: new Set(),
+        };
+
+        expect(createInstance).toHaveBeenCalledTimes(1);
+        expect(createInstance).toHaveBeenCalledWith(
+          containerModuleFactoryMetadataMock.injects[0],
+          expectedTaskContext,
+        );
+      });
+
+      it('should call containerModuleFactoryMetadata.factory()', () => {
+        expect(
+          containerModuleFactoryMetadataMock.factory,
+        ).toHaveBeenCalledTimes(1);
+        expect(containerModuleFactoryMetadataMock.factory).toHaveBeenCalledWith(
+          factoryParameterFixture,
+        );
+      });
+
+      it('should call containerModule.load()', () => {
+        expect(containerModuleMock.load).toHaveBeenCalledTimes(1);
+        expect(containerModuleMock.load).toHaveBeenCalledWith(
+          taskContextMock.services.bindingService,
+          taskContextMock.services.metadataService,
+        );
+      });
+
+      it('should return undefined', () => {
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});

--- a/packages/iocuak/src/task/actions/domain/loadFromContainerModuleFactoryMetadata.ts
+++ b/packages/iocuak/src/task/actions/domain/loadFromContainerModuleFactoryMetadata.ts
@@ -1,0 +1,43 @@
+import * as cuaktask from '@cuaklabs/cuaktask';
+
+import { ServiceId } from '../../../common/models/domain/ServiceId';
+import { ContainerModule } from '../../../containerModule/models/domain/ContainerModule';
+import { ContainerModuleFactoryMetadata } from '../../../containerModuleMetadata/models/domain/ContainerModuleFactoryMetadata';
+import { TaskContext } from '../../models/domain/TaskContext';
+import { createInstance } from './createInstance';
+
+export function loadFromContainerModuleFactoryMetadata(
+  metadata: ContainerModuleFactoryMetadata,
+  context: TaskContext,
+): void | Promise<void> {
+  const instances: unknown[] = metadata.injects.map((inject: ServiceId) =>
+    createInstance(inject, {
+      ...context,
+      servicesInstantiatedSet: new Set(),
+    }),
+  );
+
+  const containerModule: ContainerModule | Promise<ContainerModule> =
+    metadata.factory(...instances);
+
+  if (cuaktask.isPromiseLike(containerModule)) {
+    return loadModuleAsync(containerModule, context);
+  } else {
+    containerModule.load(
+      context.services.bindingService,
+      context.services.metadataService,
+    );
+  }
+}
+
+async function loadModuleAsync(
+  containerModulePromise: Promise<ContainerModule>,
+  context: TaskContext,
+): Promise<void> {
+  const containerModule: ContainerModule = await containerModulePromise;
+
+  containerModule.load(
+    context.services.bindingService,
+    context.services.metadataService,
+  );
+}


### PR DESCRIPTION
### Added
- Added `loadContainerModule`.
- Added `loadContainerModuleElementAsync`.
- Added `loadContainerModuleElement`.
- Added `loadFromContainerModuleClassMetadata`.
- Added `loadFromContainerModuleFactoryMetadata`.